### PR TITLE
Make ptvsd great again

### DIFF
--- a/11.0.Dockerfile
+++ b/11.0.Dockerfile
@@ -21,7 +21,7 @@ ENV DB_FILTER=.* \
     OPENERP_SERVER=/opt/odoo/auto/odoo.conf \
     PATH="/home/odoo/.local/bin:$PATH" \
     PIP_NO_CACHE_DIR=0 \
-    PTVSD_ARGS="-s doodba-rocks -p 6899" \
+    PTVSD_ARGS="--server-host 0.0.0.0 --port 6899" \
     PTVSD_ENABLE=0 \
     PUDB_RDB_HOST=0.0.0.0 \
     PUDB_RDB_PORT=6899 \
@@ -72,7 +72,7 @@ RUN gem install --no-rdoc --no-ri --no-update-sources bootstrap-sass --version '
 # Other facilities
 WORKDIR /opt/odoo
 RUN pip install \
-    astor git-aggregator openupgradelib ptvsd==3.0.0 pudb wdb
+    astor git-aggregator openupgradelib ptvsd pudb wdb
 COPY bin/* /usr/local/bin/
 COPY lib/odoobaselib /usr/local/lib/python3.5/dist-packages/odoobaselib
 COPY build.d common/build.d

--- a/8.0.Dockerfile
+++ b/8.0.Dockerfile
@@ -21,7 +21,7 @@ ENV DB_FILTER=.* \
     OPENERP_SERVER=/opt/odoo/auto/odoo.conf \
     PATH="/home/odoo/.local/bin:$PATH" \
     PIP_NO_CACHE_DIR=0 \
-    PTVSD_ARGS="-s doodba-rocks -p 6899" \
+    PTVSD_ARGS="--server-host 0.0.0.0 --port 6899" \
     PTVSD_ENABLE=0 \
     PUDB_RDB_HOST=0.0.0.0 \
     PUDB_RDB_PORT=6899 \
@@ -75,7 +75,7 @@ RUN gem install --no-rdoc --no-ri --no-update-sources bootstrap-sass --version '
 # Other facilities
 WORKDIR /opt/odoo
 RUN pip install \
-    astor git-aggregator openupgradelib ptvsd==3.0.0 pudb wdb
+    astor git-aggregator openupgradelib ptvsd pudb wdb
 COPY bin/* /usr/local/bin/
 COPY lib/odoobaselib /usr/local/lib/python2.7/dist-packages/odoobaselib
 COPY build.d common/build.d

--- a/README.md
+++ b/README.md
@@ -417,10 +417,13 @@ contents:
             "name": "Attach to debug in devel.yaml",
             "type": "python",
             "request": "attach",
-            "localRoot": "${workspaceRoot}/odoo",
-            "remoteRoot": "/opt/odoo",
+            "pathMappings": [
+                {
+                    "localRoot": "${workspaceRoot}/odoo",
+                    "remoteRoot": "/opt/odoo"
+                }
+            ],
             "port": 6899,
-            "secret": "doodba-rocks",
             "host": "localhost"
         }
     ]

--- a/bin/direxec
+++ b/bin/direxec
@@ -49,7 +49,7 @@ if extra_command:
             extra_command = (
                 ["python", "-m", "ptvsd"] +
                 os.environ["PTVSD_ARGS"].split() +
-                extra_command[0] + ["-"] + extra_command[1:]
+                extra_command
             )
     logger.info("Executing %s", " ".join(extra_command))
     os.execvp(extra_command[0], extra_command)


### PR DESCRIPTION
Without this patch, we were stick in an old ptvsd version, because it was the only one that was actually working, as explained in https://github.com/Microsoft/vscode-python/issues/133#issuecomment-353757512.

However, today it's the contrary: version 3.0.0 is no longer supported by Visual Studio Code, so we need to update it.

The new version has a different CLI, so it's adapted here too (BTW it was broken before too).

Usage instructions updated too.