### PR TITLE
Use OCB 12.0

### DIFF
--- a/12.0.Dockerfile
+++ b/12.0.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5-stretch AS base
+FROM python:3.7-stretch AS base
 
 # Enable Odoo user and filestore
 RUN useradd -md /home/odoo -s /bin/false odoo \
@@ -76,7 +76,7 @@ RUN pip install \
         wdb \
     && sync
 COPY bin/* /usr/local/bin/
-COPY lib/doodbalib /usr/local/lib/python3.5/site-packages/doodbalib
+COPY lib/doodbalib /usr/local/lib/python3.7/site-packages/doodbalib
 COPY build.d common/build.d
 COPY conf.d common/conf.d
 COPY entrypoint.d common/entrypoint.d
@@ -84,22 +84,20 @@ RUN mkdir -p auto/addons custom/src/private \
     && ln /usr/local/bin/direxec common/entrypoint \
     && ln /usr/local/bin/direxec common/build \
     && chmod -R a+rx common/entrypoint* common/build* /usr/local/bin \
-    && chmod -R a+rX /usr/local/lib/python3.5/site-packages/doodbalib \
+    && chmod -R a+rX /usr/local/lib/python3.7/site-packages/doodbalib \
     && sync
 
 # Execute installation script by Odoo version
 # This is at the end to benefit from cache at build time
 # https://docs.docker.com/engine/reference/builder/#/impact-on-build-caching
-# TODO Use OCA/OCB when OCB 12.0 is released
-ARG ODOO_SOURCE=odoo/odoo
+ARG ODOO_SOURCE=OCA/OCB
 ARG ODOO_VERSION=12.0
-# TODO Use "$ODOO_VERSION" when OCB or Odoo 12.0 is released
-ENV ODOO_VERSION="saas-11.5"
+ENV ODOO_VERSION="$ODOO_VERSION"
 RUN debs="libldap2-dev libsasl2-dev" \
     && apt-get update \
     && apt-get install -yqq --no-install-recommends $debs \
     && pip install -r https://raw.githubusercontent.com/$ODOO_SOURCE/$ODOO_VERSION/requirements.txt \
-    && (python3 -m compileall -q /usr/local/lib/python3.5/ || true) \
+    && (python3 -m compileall -q /usr/local/lib/python3.7/ || true) \
     && apt-get purge -yqq $debs \
     && rm -Rf /var/lib/apt/lists/* /tmp/*
 
@@ -128,8 +126,7 @@ ONBUILD CMD ["/usr/local/bin/odoo"]
 ONBUILD ARG AGGREGATE=true
 ONBUILD ARG AUTO_REQUIREMENTS=false
 ONBUILD ARG DEFAULT_REPO_PATTERN="https://github.com/OCA/{}.git"
-# TODO Use OCA/OCB when OCB 12.0 is released
-ONBUILD ARG DEFAULT_REPO_PATTERN_ODOO="https://github.com/odoo/odoo.git"
+ONBUILD ARG DEFAULT_REPO_PATTERN_ODOO="https://github.com/OCA/OCB.git"
 ONBUILD ARG DEPTH_DEFAULT=1
 ONBUILD ARG DEPTH_MERGE=100
 ONBUILD ARG CLEAN=true

--- a/12.0.Dockerfile
+++ b/12.0.Dockerfile
@@ -43,6 +43,7 @@ RUN apt-get -qq update \
         gnupg2 \
         locales-all \
         nano \
+        ruby \
         telnet \
         vim \
         zlibc \

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -24,7 +24,7 @@ PG_VERSIONS = frozenset(environ.get(
     "PG_VERSIONS", "10").split())
 SCAFFOLDINGS_DIR = join(DIR, "scaffoldings")
 
-# TODO Remove when OCB 12.0 gets released, and fix errors raised
+# TODO Remove when required OCA addons for 12.0 are released, and fix errors
 skip_12 = unittest.skipIf(
     ODOO_VERSIONS == {"12.0"},
     "Test not ready for OCB 12.0")
@@ -168,7 +168,6 @@ class ScaffoldingCase(unittest.TestCase):
                 ("bash", "-c", 'test "$(addons list -cWsale)" == crm'),
             )
 
-    @skip_12
     def test_settings(self):
         """Test settings are filled OK"""
         folder = join(SCAFFOLDINGS_DIR, "settings")
@@ -216,7 +215,6 @@ class ScaffoldingCase(unittest.TestCase):
                 *commands
             )
 
-    @skip_12
     def test_dotd(self):
         """Test environment with common ``*.d`` directories."""
         for sub_env in matrix():

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -227,7 +227,7 @@ class ScaffoldingCase(unittest.TestCase):
                 # ``custom/conf.d`` was properly concatenated
                 ("grep", "test-conf", "auto/odoo.conf"),
                 # ``custom/dependencies`` were installed
-                ("test", "!", "-e", "/usr/bin/gcc"),
+                ("test", "!", "-e", "/usr/sbin/sshd"),
                 ("test", "!", "-e", "/var/lib/apt/lists/lock"),
                 ("busybox", "whoami"),
                 ("bash", "-c", "echo $NODE_PATH"),
@@ -267,7 +267,7 @@ class ScaffoldingCase(unittest.TestCase):
                                 'print(werkzeug.__version__)")" == 0.14.1')),
                 # apt_build.txt
                 ("test", "-f", "custom/dependencies/apt_build.txt"),
-                ("test", "!", "-e", "/usr/bin/gcc"),
+                ("test", "!", "-e", "/usr/sbin/sshd"),
                 # apt-without-sequence.txt
                 ("test", "-f", "custom/dependencies/apt-without-sequence.txt"),
                 ("test", "!", "-e", "/bin/busybox"),

--- a/tests/scaffoldings/dependencies/custom/dependencies/apt_build.txt
+++ b/tests/scaffoldings/dependencies/custom/dependencies/apt_build.txt
@@ -1,5 +1,7 @@
 # This installs gcc among other things
 build-essential
-# This is the basic need to build any python extensions
+# This is the basic need to build any python extensions in v11-
 python-dev
 python3-dev
+# Just to test it is removed later
+openssh-server

--- a/tests/scaffoldings/dotd/custom/dependencies/apt_build.txt
+++ b/tests/scaffoldings/dotd/custom/dependencies/apt_build.txt
@@ -1,5 +1,7 @@
 # This installs gcc among other things
 build-essential
-# This is the basic need to build any python extensions
+# This is the basic need to build any python extensions on v11-
 python-dev
 python3-dev
+# Just to test it is removed after building
+openssh-server


### PR DESCRIPTION
- Branch 12.0 of OCB has been released, so use it now.
- Enable some tests that should work now. There are still anothers that are disabled.
- Use Python 3.7, now that it has been discovered [it is officially supported][1] ~~and [is going to be tested in OCA repos][2]~~.

[1]: https://twitter.com/__yajo/status/1045228965928062977
[2]: https://twitter.com/moylop260/status/1045230320403062784