### PR TITLE
Allow to find dependant addons only

### DIFF
--- a/bin/addons
+++ b/bin/addons
@@ -24,6 +24,9 @@ parser.add_argument(
     "-c", "--core", action="store_true",
     help="Use all Odoo core addons")
 parser.add_argument(
+    "-d", "--dependencies", action="store_true",
+    help="Use only dependencies of selected addons")
+parser.add_argument(
     "-e", "--extra", action="store_true",
     help="Use all extra addons")
 parser.add_argument(
@@ -53,6 +56,7 @@ parser.add_argument(
 
 # Generate the matching addons set
 args = parser.parse_args()
+dependencies = {"base"}
 addons = set(args.with_)
 without = set(args.without)
 if addons & without:
@@ -80,6 +84,7 @@ try:
                         continue
                     else:
                         installable = manifest.get("installable", True)
+                        dependencies += set(manifest.get("depends", set()))
                         break
                 if not installable:
                     continue
@@ -88,6 +93,9 @@ try:
             addons.add(addon)
 except AddonsConfigError as error:
     sys.exit(error.message)
+# Use dependencies instead, if requested
+if args.dependencies:
+    addons = dependencies - addons
 
 # Do the required action
 if not addons:

--- a/bin/addons
+++ b/bin/addons
@@ -84,7 +84,7 @@ try:
                         continue
                     else:
                         installable = manifest.get("installable", True)
-                        dependencies += set(manifest.get("depends", set()))
+                        dependencies.update(manifest.get("depends", []))
                         break
                 if not installable:
                     continue

--- a/bin/addons
+++ b/bin/addons
@@ -61,6 +61,8 @@ addons = set(args.with_)
 without = set(args.without)
 if addons & without:
     sys.exit("Cannot include and exclude the same addon!")
+if args.dependencies and args.fullpath:
+    sys.exit("Unsupported combination of --dependencies and --fullpath")
 try:
     for addon, repo in addons_config(strict=args.explicit):
         if addon in without:
@@ -70,24 +72,18 @@ try:
         private_ok = args.private and repo == PRIVATE
         if private_ok or core_ok or extra_ok:
             addon_path = os.path.join(SRC_DIR, repo, addon)
-            if args.installable:
-                installable = False
-                manifests = list(MANIFESTS)
-                while True:
-                    try:
-                        manifest = os.path.join(addon_path, manifests.pop())
-                        with open(manifest, "r") as code:
-                            manifest = ast.literal_eval(code.read())
-                    except IndexError:
+            manifest = {}
+            for manifest_name in MANIFESTS:
+                try:
+                    manifest_path = os.path.join(addon_path, manifest_name)
+                    with open(manifest_path, "r") as code:
+                        manifest = ast.literal_eval(code.read())
                         break
-                    except IOError:
-                        continue
-                    else:
-                        installable = manifest.get("installable", True)
-                        dependencies.update(manifest.get("depends", []))
-                        break
-                if not installable:
+                except IOError:
                     continue
+            if args.installable and not manifest.get("installable", True):
+                continue
+            dependencies.update(manifest.get("depends", []))
             if args.fullpath and args.action == "list":
                 addon = addon_path
             addons.add(addon)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -110,8 +110,6 @@ class ScaffoldingCase(unittest.TestCase):
                  'test "$(addons list -p)" == disabled_addon,private_addon'),
                 ("bash", "-c", 'test "$(addons list -ip)" == private_addon'),
                 ("bash", "-c", 'addons list -c | grep ,crm,'),
-                ("bash", "-c",
-                 'test "$(addons list -ped)" == base,web,website'),
                 # absent_addon is missing and should fail
                 ("bash", "-c", "! addons list -px"),
             )
@@ -139,6 +137,8 @@ class ScaffoldingCase(unittest.TestCase):
             self.compose_test(
                 project_dir,
                 dict(sub_env, DBNAME="prod"),
+                ("bash", "-c",
+                 'test "$(addons list -ped)" == base,web,website'),
                 # ``dummy_addon`` and ``private_addon`` exist
                 ("test", "-d", "auto/addons/dummy_addon"),
                 ("test", "-h", "auto/addons/dummy_addon"),

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -110,6 +110,8 @@ class ScaffoldingCase(unittest.TestCase):
                  'test "$(addons list -p)" == disabled_addon,private_addon'),
                 ("bash", "-c", 'test "$(addons list -ip)" == private_addon'),
                 ("bash", "-c", 'addons list -c | grep ,crm,'),
+                ("bash", "-c",
+                 'test "$(addons list -ped)" == base,web,website'),
                 # absent_addon is missing and should fail
                 ("bash", "-c", "! addons list -px"),
             )

--- a/tests/scaffoldings/dotd/custom/src/dummy_repo/dummy_addon/__manifest__.py
+++ b/tests/scaffoldings/dotd/custom/src/dummy_repo/dummy_addon/__manifest__.py
@@ -1,4 +1,5 @@
 {
     "name": "dummy_addon",
+    "depends": ["web"],
     "installable": True,
 }

--- a/tests/scaffoldings/dotd/custom/src/private/private_addon/__openerp__.py
+++ b/tests/scaffoldings/dotd/custom/src/private/private_addon/__openerp__.py
@@ -1,3 +1,4 @@
 {
     "name": "private_addon",
+    "depends": ["dummy_addon", "website"],
 }


### PR DESCRIPTION
This tool is required to be able to apply the same testing workflow as found in OCA, namely:

1. Install dependencies of chosen addons.
2. Test & install chosen addons.

See https://github.com/OCA/server-ux/pull/32 and https://github.com/odoo/odoo/pull/27883 to understand the motivation behind this. Take a :coffee: first :stuck_out_tongue_winking_eye:.