### PR TITLE
Update python in v11 image (switch base)

### DIFF
--- a/11.0.Dockerfile
+++ b/11.0.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:9 AS base
+FROM python:3.5-stretch AS base
 
 # Enable Odoo user and filestore
 RUN useradd -md /home/odoo -s /bin/false odoo \
@@ -38,13 +38,16 @@ ENV DB_FILTER=.* \
 RUN apt-get -qq update \
     && apt-get -yqq upgrade \
     && apt-get install -yqq --no-install-recommends \
-        python3 ruby-compass \
-        fontconfig libfreetype6 libxml2 libxslt1.1 libjpeg62-turbo zlib1g \
-        libfreetype6 liblcms2-2 libtiff5 tk tcl libpq5 \
-        libldap-2.4-2 libsasl2-2 libx11-6 libxext6 libxrender1 \
-        locales-all zlibc \
-        bzip2 ca-certificates curl gettext-base git gnupg2 nano vim \
-        openssh-client telnet xz-utils \
+        chromium \
+        gettext-base \
+        gnupg2 \
+        locales-all \
+        ruby-compass \
+        nano \
+        ruby \
+        telnet \
+        vim \
+        zlibc \
     && echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main' >> /etc/apt/sources.list.d/postgresql.list \
     && curl -SL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
     && curl https://bootstrap.pypa.io/get-pip.py | python3 /dev/stdin \
@@ -56,9 +59,7 @@ RUN apt-get -qq update \
     && apt-get install -yqq --no-install-recommends ./wkhtmltox.deb \
     && rm wkhtmltox.deb \
     && wkhtmltopdf --version \
-    && apt-get -yqq purge python2.7 \
-    && apt-get -yqq autoremove \
-    && rm -Rf /var/lib/apt/lists/*
+    && rm -Rf /var/lib/apt/lists/* /tmp/*
 
 # Special case to get latest Less and PhantomJS
 RUN ln -s /usr/bin/nodejs /usr/local/bin/node \
@@ -72,11 +73,18 @@ RUN gem install --no-rdoc --no-ri --no-update-sources bootstrap-sass --version '
 # Other facilities
 WORKDIR /opt/odoo
 RUN pip install \
-    astor git-aggregator openupgradelib ptvsd pudb wdb
+        astor \
+        git-aggregator \
+        openupgradelib \
+        pg_activity \
+        ptvsd \
+        pudb \
+        wdb \
+    && sync
 COPY bin/* /usr/local/bin/
-COPY lib/doodbalib /usr/local/lib/python3.5/dist-packages/doodbalib
-RUN ln -s /usr/local/lib/python3.5/dist-packages/doodbalib \
-    /usr/local/lib/python3.5/dist-packages/odoobaselib
+COPY lib/doodbalib /usr/local/lib/python3.5/site-packages/doodbalib
+RUN ln -s /usr/local/lib/python3.5/site-packages/doodbalib \
+    /usr/local/lib/python3.5/site-packages/odoobaselib
 COPY build.d common/build.d
 COPY conf.d common/conf.d
 COPY entrypoint.d common/entrypoint.d
@@ -84,8 +92,7 @@ RUN mkdir -p auto/addons custom/src/private \
     && ln /usr/local/bin/direxec common/entrypoint \
     && ln /usr/local/bin/direxec common/build \
     && chmod -R a+rx common/entrypoint* common/build* /usr/local/bin \
-    && chmod -R a+rX /usr/local/lib/python3.5/dist-packages/doodbalib \
-    && ln -s $(which python3) /usr/local/bin/python \
+    && chmod -R a+rX /usr/local/lib/python3.5/site-packages/doodbalib \
     && sync
 
 # Execute installation script by Odoo version
@@ -94,24 +101,14 @@ RUN mkdir -p auto/addons custom/src/private \
 ARG ODOO_SOURCE=OCA/OCB
 ARG ODOO_VERSION=11.0
 ENV ODOO_VERSION="$ODOO_VERSION"
-RUN apt-get update \
-    && apt-get install -y \
-        build-essential \
-        libevent-dev \
-        libjpeg-dev \
-        libldap2-dev \
-        libsasl2-dev \
-        libssl-dev \
-        libxml2-dev \
-        libxslt1-dev \
-        python3-dev \
-        zlib1g-dev \
-    && pip install -r https://raw.githubusercontent.com/$ODOO_SOURCE/$ODOO_VERSION/requirements.txt \
-    && pip install pg_activity \
+RUN debs="libldap2-dev libsasl2-dev" \
+    && apt-get update \
+    && apt-get install -yqq --no-install-recommends $debs \
+    && pip install \
+        -r https://raw.githubusercontent.com/$ODOO_SOURCE/$ODOO_VERSION/requirements.txt \
     && (python3 -m compileall -q /usr/local/lib/python3.5/ || true) \
-    && apt-get purge -yqq build-essential '*-dev' \
-    && apt-mark -qq manual '*' \
-    && rm -Rf /var/lib/apt/lists/*
+    && apt-get purge -yqq $debs \
+    && rm -Rf /var/lib/apt/lists/* /tmp/*
 
 # HACK Special case for Werkzeug
 USER odoo

--- a/README.md
+++ b/README.md
@@ -352,7 +352,10 @@ package managers:
 
 - `apt_build.txt`: build-time dependencies, installed before any others and
   removed after all the others too. Usually these would include Debian packages
-  such as `build-essential` or `python-dev`.
+  such as `build-essential` or `python-dev`. From Doodba 11.0, this is most
+  likely not needed, as build dependencies are shipped with the image, and
+  local python develpment headers should be used instead of those downloaded
+  from apt.
 - `apt.txt`: run-time dependencies installed by apt.
 - `gem.txt`: run-time dependencies installed by gem.
 - `npm.txt`: run-time dependencies installed by npm.


### PR DESCRIPTION
The outdated and buggy Python 3.5 version that Debian 9 ships was triggering werid behaviors in some production instances.

I switch here the base to Docker Hub's `python:3.5-stretch`, which shares the same underlying OS, but uses latest Python 3.5 (3.5.6 as of today) and gets updates faster.

The main upgrade problem would be that projects adding `python-dev` to their `apt_build.txt` files should remove it now. Not a big problem nor fix, so it seems legit for the stable release.