### PR TITLE
Change default fonts to liberation

### DIFF
--- a/11.0.Dockerfile
+++ b/11.0.Dockerfile
@@ -39,6 +39,7 @@ RUN apt-get -qq update \
     && apt-get -yqq upgrade \
     && apt-get install -yqq --no-install-recommends \
         chromium \
+        fonts-liberation2 \
         gettext-base \
         gnupg2 \
         locales-all \

--- a/12.0.Dockerfile
+++ b/12.0.Dockerfile
@@ -39,6 +39,7 @@ RUN apt-get -qq update \
     && apt-get -yqq upgrade \
     && apt-get install -yqq --no-install-recommends \
         chromium \
+        fonts-liberation2 \
         gettext-base \
         gnupg2 \
         locales-all \

--- a/8.0.Dockerfile
+++ b/8.0.Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         python ruby-compass \
         fontconfig libfreetype6 libxml2 libxslt1.1 libjpeg62-turbo zlib1g \
+        fonts-liberation \
         libfreetype6 liblcms2-2 libopenjpeg5 libtiff5 tk tcl libpq5 \
         libldap-2.4-2 libsasl2-2 libx11-6 libxext6 libxrender1 \
         locales-all zlibc \


### PR DESCRIPTION
Current fonts shipped by Debian do not render fine in Adobe PDF on Windows and Mac OS.

Most users will use those OS & PDF reader combination, and [Odoo demos and runbots use MS fonts][1].

So, in the hope of providing an opinionated sane default that makes most users happy, we are going to ship Liberation fonts by default, which are an open source alternative to MS fonts that, according to tests, render just fine everywhere.

If anybody wants a more corporative font, they should use it in their reports and install it from apt with provided tools.

[1]: https://github.com/odoo/odoo/issues/27487#issuecomment-431847389