### PR TITLE
Fix error on Doodba QA when private folder is empty

### DIFF
--- a/lib/doodbalib/__init__.py
+++ b/lib/doodbalib/__init__.py
@@ -110,7 +110,9 @@ def addons_config(strict=False):
             full_glob = os.path.join(SRC_DIR, repo, partial_glob)
             found = glob(full_glob)
             if not found:
-                missing_glob.add(full_glob)
+                # Projects without private addons should never fail
+                if (repo, partial_glob) != (PRIVATE, "*"):
+                    missing_glob.add(full_glob)
                 logger.debug(
                     "Skipping unexpandable glob '%s'",
                     full_glob)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -200,6 +200,7 @@ class ScaffoldingCase(unittest.TestCase):
             ("test", "-d", "/opt/odoo/custom/src/private"),
             ("test", "-d", "/opt/odoo/custom/ssh"),
             ("test", "-x", "/usr/local/bin/unittest"),
+            ("addons", "list", "-pix"),
             ("pg_activity", "--version"),
             # Must be able to install base addon
             ODOO_PREFIX + ("--init", "base"),

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -200,7 +200,7 @@ class ScaffoldingCase(unittest.TestCase):
             ("test", "-d", "/opt/odoo/custom/src/private"),
             ("test", "-d", "/opt/odoo/custom/ssh"),
             ("test", "-x", "/usr/local/bin/unittest"),
-            ("addons", "list", "-pix"),
+            ("addons", "list", "-cpix"),
             ("pg_activity", "--version"),
             # Must be able to install base addon
             ODOO_PREFIX + ("--init", "base"),


### PR DESCRIPTION
Since #182, the `addons-install` script in doodba-qa, in projects without private addons, yielded this error:

    Addons not found:
    {'/opt/odoo/custom/src/private/*'}

This should never be an error, as projects without private addons are not only supported but actually encouraged!

So, I add here this specific exception.