### PR TITLE
Restore ability to unfilter addons

### DIFF
--- a/build.d/400-clean
+++ b/build.d/400-clean
@@ -10,7 +10,7 @@ if not CLEAN:
     logger.warning("Not cleaning garbage")
     sys.exit()
 
-addons = set(addons_config(False))
+addons = set(addons_config(filtered=False))
 repos = {addon[1] for addon in addons} | {CORE, PRIVATE}
 for directory in os.listdir(SRC_DIR):
     # Special directories must be preserved

--- a/lib/doodbalib/__init__.py
+++ b/lib/doodbalib/__init__.py
@@ -70,8 +70,12 @@ class AddonsConfigError(Exception):
         self.message = message
 
 
-def addons_config(strict=False):
+def addons_config(filtered=True, strict=False):
     """Yield addon name and path from ``ADDONS_YAML``.
+
+    :param bool filtered:
+        Use ``False`` to include all addon definitions. Use ``True`` (default)
+        to include only those matched by ``ONLY`` clauses, if any.
 
     :param bool strict:
         Use ``True`` to raise an exception if any declared addon is not found.
@@ -88,8 +92,8 @@ def addons_config(strict=False):
             for doc in yaml.load_all(addons_file):
                 # Skip sections with ONLY and that don't match
                 only = doc.pop("ONLY", {})
-                if any(os.environ.get(key) not in values
-                       for key, values in only.items()):
+                if filtered and any(os.environ.get(key) not in values
+                                    for key, values in only.items()):
                     logger.debug("Skipping section with ONLY %s", only)
                     continue
                 # Flatten all sections in a single dict

--- a/lib/doodbalib/__init__.py
+++ b/lib/doodbalib/__init__.py
@@ -92,8 +92,11 @@ def addons_config(filtered=True, strict=False):
             for doc in yaml.load_all(addons_file):
                 # Skip sections with ONLY and that don't match
                 only = doc.pop("ONLY", {})
-                if filtered and any(os.environ.get(key) not in values
-                                    for key, values in only.items()):
+                if not filtered:
+                    doc.setdefault(CORE, ["*"])
+                    doc.setdefault(PRIVATE, ["*"])
+                elif any(os.environ.get(key) not in values
+                         for key, values in only.items()):
                     logger.debug("Skipping section with ONLY %s", only)
                     continue
                 # Flatten all sections in a single dict


### PR DESCRIPTION
This option was wrongly removed in 7ab4d1f680c5d4f0ca7e9254074c5e6a94e0a3ad, so I'm reverting that change.

We need to know the total addons used, to avoid cleaning them on image build.