### PR TITLE
Install fonts-liberation2 in Debian 8 builds

### DIFF
--- a/8.0.Dockerfile
+++ b/8.0.Dockerfile
@@ -49,6 +49,8 @@ RUN apt-get update \
     && curl https://bootstrap.pypa.io/get-pip.py | python /dev/stdin \
     && curl -sL https://deb.nodesource.com/setup_6.x | bash - \
     && apt-get install -yqq nodejs \
+    && curl -SLo fonts-liberation2.deb http://ftp.debian.org/debian/pool/main/f/fonts-liberation2/fonts-liberation2_2.00.1-3_all.deb \
+    && dpkg --install wkhtmltox.deb \
     && curl -SLo wkhtmltox.deb https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/${WKHTMLTOPDF_VERSION}/wkhtmltox_${WKHTMLTOPDF_VERSION}-1.jessie_amd64.deb \
     && echo "${WKHTMLTOPDF_CHECKSUM}  wkhtmltox.deb" | sha256sum -c - \
     && (dpkg --install wkhtmltox.deb || true) \

--- a/8.0.Dockerfile
+++ b/8.0.Dockerfile
@@ -50,7 +50,7 @@ RUN apt-get update \
     && curl -sL https://deb.nodesource.com/setup_6.x | bash - \
     && apt-get install -yqq nodejs \
     && curl -SLo fonts-liberation2.deb http://ftp.debian.org/debian/pool/main/f/fonts-liberation2/fonts-liberation2_2.00.1-3_all.deb \
-    && dpkg --install wkhtmltox.deb \
+    && dpkg --install fonts-liberation2.deb \
     && curl -SLo wkhtmltox.deb https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/${WKHTMLTOPDF_VERSION}/wkhtmltox_${WKHTMLTOPDF_VERSION}-1.jessie_amd64.deb \
     && echo "${WKHTMLTOPDF_CHECKSUM}  wkhtmltox.deb" | sha256sum -c - \
     && (dpkg --install wkhtmltox.deb || true) \


### PR DESCRIPTION
This package comes from Debian 9, but it is needed because only Liberation 2.x fonts support "ZERO WIDTH NO-BREAK SPACE (U+FEFF)" character, used by Odoo from https://github.com/odoo/odoo/commit/cb2a3afa7e010d1cd7a01c64f5c3ac58b6fd76d2 onwards.

For instance, on Odoo 10 under Doodba, before this patch (and after having merged #181), printing the general ledger report with demo data resulted in this:

![captura de pantalla de 2018-11-20 13-21-44](https://user-images.githubusercontent.com/973709/48776385-a541cc80-ecc7-11e8-8f62-b1285d0ea1c5.png)

This is after the patch:

![captura de pantalla de 2018-11-20 13-21-59](https://user-images.githubusercontent.com/973709/48776397-ab37ad80-ecc7-11e8-94b2-89e796b4e646.png)
