### PR TITLE
Fix removal of linked directories

### DIFF
--- a/build.d/400-clean
+++ b/build.d/400-clean
@@ -25,7 +25,10 @@ for directory in os.listdir(SRC_DIR):
     # Remove directories not listed in addons.yaml
     if directory not in repos:
         logger.info("Removing directory %s", full)
-        shutil.rmtree(full)
+        try:
+          shutil.rmtree(full)
+        except OSError:
+          os.unlink(full)
         continue
 
     # Traverse addons
@@ -37,4 +40,7 @@ for directory in os.listdir(SRC_DIR):
         # Remove addon if not used
         if (subdirectory, directory) not in addons:
             logger.info("Removing subdirectory %s", subfull)
-            shutil.rmtree(subfull)
+            try:
+              shutil.rmtree(subfull)
+            except OSError:
+              os.unlink(subfull)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -245,7 +245,9 @@ class ScaffoldingCase(unittest.TestCase):
                 ("python", "-c", "import cfssl"),
                 # Local executable binaries found in $PATH
                 ("sh", "-c", "pip install --user -q flake8 && which flake8"),
+                # Addon cleanup works correctly
                 ("test", "!", "-e", "custom/src/private/dummy_addon"),
+                ("test", "!", "-e", "custom/src/dummy_repo/dummy_link"),
                 ("test", "-d", "custom/src/private/private_addon"),
                 ("test", "-f", "custom/src/private/private_addon/__init__.py"),
                 ("test", "-e", "auto/addons/private_addon"),

--- a/tests/scaffoldings/dotd/custom/src/dummy_repo/dummy_link
+++ b/tests/scaffoldings/dotd/custom/src/dummy_repo/dummy_link
@@ -1,0 +1,1 @@
+dummy_addon


### PR DESCRIPTION
This PR is proposed to fix the issue #189 

As proposed in the mentioned issue, a try/catch has been implemented and successfully tested for my use case, however, it may be that OSError is raised for another reason than because directory is a link and therefore the script would still fail when trying to unlink it...