### PR TITLE
Use backwards-compatible universal_newlines argument

### DIFF
--- a/qa/insider
+++ b/qa/insider
@@ -42,7 +42,8 @@ try:
     subprocess.check_call(
         cmd,
         stdout=sys.stderr,
-        **({"text": True} if sys.version_info.major > 2 else {}),
+        # TODO Change to text=True when we support Python 3.7+ only
+        universal_newlines=True,
     )
 except subprocess.CalledProcessError as error:
     logger.debug("Subcommand exception:", exc_info=True)
@@ -55,10 +56,15 @@ finally:
     logger.debug("Zipping /qa/artifacts in %s.zip", artifacts_zip_path)
     shutil.make_archive(artifacts_zip_path, "zip", "/qa/artifacts")
     artifacts_zip_path += ".zip"
-    with open(artifacts_zip_path, "rb") as zip_fd, \
-            os.fdopen(sys.stdout.fileno(), "wb", closefd=False) as stdout:
-        stdout.write(zip_fd.read())
-        stdout.flush()
+    with open(artifacts_zip_path, "rb") as zip_fd:
+        if sys.version_info >= (3,):
+            with os.fdopen(sys.stdout.fileno(), "wb", closefd=False) as stdout:
+                stdout.write(zip_fd.read())
+                stdout.flush()
+        # TODO Delete when dropping Python 2 (Odoo 10.0 and lower) support,
+        # as this is a less safe and idiomatic way of doing the same as above
+        else:
+            os.write(sys.stdout.fileno(), zip_fd.read())
 
     logger.debug("Deleting %s", artifacts_zip_path)
     os.unlink(artifacts_zip_path)


### PR DESCRIPTION
I was using the `text=True` argument, only in PY3+, for `subprocess.check_call`, but it turns out that argument only exists in PY3.7+, and this code is executed also by PY2.7 and PY3.5, depending on the Odoo image version.

Instead, I just use now `universal_newlines=True`, which is the backwards-compatible equivalent to `text=True`. We'll change that when that backwards compatibility is removed and/or we only support PY3.7+ (a.k.a. only Odoo 12.0+).

This fixes the red build introduced by #193.