### PR TITLE
Include click-odoo-contrib packages

### DIFF
--- a/11.0.Dockerfile
+++ b/11.0.Dockerfile
@@ -76,6 +76,7 @@ RUN gem install --no-rdoc --no-ri --no-update-sources bootstrap-sass --version '
 WORKDIR /opt/odoo
 RUN pip install \
         astor \
+        click-odoo-contrib \
         git-aggregator \
         openupgradelib \
         pg_activity \

--- a/12.0.Dockerfile
+++ b/12.0.Dockerfile
@@ -71,6 +71,7 @@ RUN ln -s /usr/bin/nodejs /usr/local/bin/node \
 WORKDIR /opt/odoo
 RUN pip install \
         astor \
+        click-odoo-contrib \
         git-aggregator \
         openupgradelib \
         pg_activity \

--- a/8.0.Dockerfile
+++ b/8.0.Dockerfile
@@ -79,7 +79,14 @@ RUN gem install --no-rdoc --no-ri --no-update-sources bootstrap-sass --version '
 # Other facilities
 WORKDIR /opt/odoo
 RUN pip install \
-    git-aggregator openupgradelib ptvsd pudb virtualenv wdb
+        click-odoo-contrib \
+        git-aggregator \
+        openupgradelib \
+        ptvsd \
+        pudb \
+        virtualenv \
+        wdb \
+    && sync
 COPY bin/* /usr/local/bin/
 COPY lib/doodbalib /usr/local/lib/python2.7/dist-packages/doodbalib
 RUN ln -s /usr/local/lib/python2.7/dist-packages/doodbalib \

--- a/README.md
+++ b/README.md
@@ -421,6 +421,12 @@ configuration.
 
 Call `addons --help` for usage instructions.
 
+### `click-odoo` and related scripts
+
+The great [`click-odoo`][] scripting framework and the collection of scripts
+found in [`click-odoo-contrib`][] are included. Refer to their sites to know
+how to use them.
+
 ### [`nano`][]
 
 The CLI text editor we all know, just in case you need to inspect some bug in
@@ -1318,6 +1324,8 @@ scaffolding versions is preserved.
 [`private`]: #optodoocustomsrcprivate
 [`PYTHONOPTIMIZE=1`]: https://docs.python.org/3/using/cmdline.html#envvar-PYTHONOPTIMIZE
 [`repos.yaml`]: #optodoocustomsrcreposyaml
+[`click-odoo`]: https://github.com/acsone/click-odoo
+[`click-odoo-contrib`]: https://github.com/acsone/click-odoo-contrib
 [builds]: https://hub.docker.com/r/tecnativa/doodba/builds/
 [development]: #development
 [docker-socket-proxy]: https://hub.docker.com/r/tecnativa/docker-socket-proxy/

--- a/bin/autoupdate
+++ b/bin/autoupdate
@@ -1,6 +1,11 @@
 #!/usr/local/bin/python-odoo-shell
+import logging
 import os
 
+_logger = logging.getLogger("autoupdate")
+
+# TODO Delete this script at some point
+_logger.warning("`autoupdate` is DEPRECATED. Use click-odoo-update instead.")
 
 # Note: ``module_auto_update`` must be installed in Odoo for this to work.
 try:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -221,6 +221,7 @@ class ScaffoldingCase(unittest.TestCase):
             ODOO_PREFIX + ("--init", "base"),
             # Auto updater must work
             ("autoupdate",),
+            ("click-odoo-update",),
         )
         smallest_dir = join(SCAFFOLDINGS_DIR, "smallest")
         for sub_env in matrix(odoo_skip={"8.0"}):


### PR DESCRIPTION
This should let us use click-odoo-update instead of autoupdate, and start moving custom scripts to a broader audience and a better supported odoo scripting framework.