### PR TITLE
Include click-odoo-update with parallel support

### DIFF
--- a/11.0.Dockerfile
+++ b/11.0.Dockerfile
@@ -76,7 +76,7 @@ RUN gem install --no-rdoc --no-ri --no-update-sources bootstrap-sass --version '
 WORKDIR /opt/odoo
 RUN pip install \
         astor \
-        click-odoo-contrib \
+        git+https://github.com/Tecnativa/click-odoo-contrib.git@update-parallel-db-lock-watcher#egg=click-odoo-contrib \
         git-aggregator \
         openupgradelib \
         pg_activity \

--- a/12.0.Dockerfile
+++ b/12.0.Dockerfile
@@ -71,7 +71,7 @@ RUN ln -s /usr/bin/nodejs /usr/local/bin/node \
 WORKDIR /opt/odoo
 RUN pip install \
         astor \
-        click-odoo-contrib \
+        git+https://github.com/Tecnativa/click-odoo-contrib.git@update-parallel-db-lock-watcher#egg=click-odoo-contrib \
         git-aggregator \
         openupgradelib \
         pg_activity \

--- a/8.0.Dockerfile
+++ b/8.0.Dockerfile
@@ -79,7 +79,7 @@ RUN gem install --no-rdoc --no-ri --no-update-sources bootstrap-sass --version '
 # Other facilities
 WORKDIR /opt/odoo
 RUN pip install \
-        click-odoo-contrib \
+        git+https://github.com/Tecnativa/click-odoo-contrib.git@update-parallel-db-lock-watcher#egg=click-odoo-contrib \
         git-aggregator \
         openupgradelib \
         ptvsd \


### PR DESCRIPTION
This is a preview feature.

Before https://github.com/Tecnativa/doodba/pull/200, the only way to autoupdate addons was to use [OCA's `module_auto_update` module](https://www.odoo.com/apps/modules/11.0/module_auto_update/). As a preview feature, I'm pre-merging https://github.com/acsone/click-odoo-contrib/pull/38 here in Doodba, to allow trusted parallel upgrades everywhere.

However, this should be considered a beta feature.

This commit should be reverted when the above PR is merged in upstream click-odoo-contrib package.

Closes https://github.com/Tecnativa/doodba/pull/160.