### PR TITLE
Use tecnativa/postgres-autoconf in dotd tests

### DIFF
--- a/tests/scaffoldings/dotd/docker-compose.yaml
+++ b/tests/scaffoldings/dotd/docker-compose.yaml
@@ -18,7 +18,7 @@ services:
       - filestore:/var/lib/odoo:z
 
   postgresql:
-    image: postgres:${DB_VERSION}-alpine
+    image: tecnativa/postgres-autoconf:${DB_VERSION}-alpine
     environment:
       POSTGRES_USER: another_odoo
       POSTGRES_PASSWORD: anotherodoopassword


### PR DESCRIPTION

This will just test that this image that will be introduced in https://github.com/Tecnativa/doodba-scaffolding/pull/26 is a drop-in replacement for most use cases.