### PR TITLE
Supress yaml.load security warning

### DIFF
--- a/lib/doodbalib/__init__.py
+++ b/lib/doodbalib/__init__.py
@@ -90,7 +90,7 @@ def addons_config(filtered=True, strict=False):
     all_globs = {}
     try:
         with open(ADDONS_YAML) as addons_file:
-            for doc in yaml.load_all(addons_file):
+            for doc in yaml.safe_load_all(addons_file):
                 # Skip sections with ONLY and that don't match
                 only = doc.pop("ONLY", {})
                 if not filtered:


### PR DESCRIPTION

Last builds were saying about previous call to `yaml.load()`:

    /usr/local/lib/python3.5/site-packages/doodbalib/__init__.py:93: YAMLLoadWarning: calling yaml.load_all() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.

Using the safe loader now.