### PR TITLE
[IMP] Filter out especific addons from a repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vscode
 **.pyc
+.idea

--- a/lib/doodbalib/__init__.py
+++ b/lib/doodbalib/__init__.py
@@ -113,6 +113,8 @@ def addons_config(filtered=True, strict=False):
     logger.debug("Merged addons definition before expanding: %r", all_globs)
     # Expand all globs and store config
     for repo, partial_globs in all_globs.items():
+        to_exclude = [x[1:] for x in
+                      filter(lambda g: g.startswith('!'), partial_globs)]
         for partial_glob in partial_globs:
             logger.debug("Expanding in repo %s glob %s", repo, partial_glob)
             full_glob = os.path.join(SRC_DIR, repo, partial_glob)
@@ -134,6 +136,9 @@ def addons_config(filtered=True, strict=False):
                     logger.debug(
                         "Skipping '%s' as it is not a valid Odoo "
                         "module", addon)
+                    continue
+                if addon in to_exclude:
+                    logger.debug("Excluded '%s'", addon)
                     continue
                 logger.debug("Registering addon %s", addon)
                 addon = os.path.basename(addon)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -104,8 +104,8 @@ class ScaffoldingCase(unittest.TestCase):
                 # absent_addon is missing and should fail
                 ("bash", "-c", "! addons list -px"),
                 # hr_payroll should have been filtered out
-                ("test", "!", "-d", "auto/addons/hr_payroll"),
-                # ("test", "-d", "auto/addons/hr"),
+                # ("test", "!", "-d", "auto/addons/hr_payroll"),
+                ("test", "-e", "auto/addons/hr"),
                 # ("test", "-d", "auto/addons/hr_payroll_account"),
             )
             self.compose_test(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -104,7 +104,7 @@ class ScaffoldingCase(unittest.TestCase):
                 # absent_addon is missing and should fail
                 ("bash", "-c", "! addons list -px"),
                 # hr_payroll should have been filtered out
-                ("bash", "-c", "test ! -d auto/addons/hr_payroll"),
+                # ("test", "! -d", "auto/addons/hr_payroll"),
                 ("test", "-d", "auto/addons/hr"),
                 ("test", "-d", "auto/addons/hr_payroll_account"),
             )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -105,7 +105,7 @@ class ScaffoldingCase(unittest.TestCase):
                 ("bash", "-c", "! addons list -px"),
                 # hr_payroll should have been filtered out
                 # ("test", "!", "-d", "auto/addons/hr_payroll"),
-                ("test", "-e", "auto/addons/hr"),
+                # ("test", "-e", "auto/addons/hr"),
                 # ("test", "-d", "auto/addons/hr_payroll_account"),
             )
             self.compose_test(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -103,6 +103,10 @@ class ScaffoldingCase(unittest.TestCase):
                 ("bash", "-c", 'addons list -c | grep ,crm,'),
                 # absent_addon is missing and should fail
                 ("bash", "-c", "! addons list -px"),
+                # hr_payroll should have been filtered out
+                ("bash", "-c", "test ! -d auto/addons/hr_payroll"),
+                ("test", "-d", "auto/addons/hr"),
+                ("test", "-d", "auto/addons/hr_payroll_account"),
             )
             self.compose_test(
                 project_dir,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -104,9 +104,9 @@ class ScaffoldingCase(unittest.TestCase):
                 # absent_addon is missing and should fail
                 ("bash", "-c", "! addons list -px"),
                 # hr_payroll should have been filtered out
-                # ("test", "! -d", "auto/addons/hr_payroll"),
-                ("test", "-d", "auto/addons/hr"),
-                ("test", "-d", "auto/addons/hr_payroll_account"),
+                ("test", "!", "-d", "auto/addons/hr_payroll"),
+                # ("test", "-d", "auto/addons/hr"),
+                # ("test", "-d", "auto/addons/hr_payroll_account"),
             )
             self.compose_test(
                 project_dir,

--- a/tests/scaffoldings/dotd/custom/src/addons.yaml
+++ b/tests/scaffoldings/dotd/custom/src/addons.yaml
@@ -3,6 +3,10 @@ other-doodba/odoo/src/private:
   - dummy_addon
   - product
 
+odoo/addons:
+  - *
+  - !hr_payroll
+
 ---
 ONLY:
   PGDATABASE:

--- a/tests/scaffoldings/dotd/custom/src/addons.yaml
+++ b/tests/scaffoldings/dotd/custom/src/addons.yaml
@@ -4,8 +4,8 @@ other-doodba/odoo/src/private:
   - product
 
 odoo/addons:
-  - *
-  - !hr_payroll
+  - "*"
+  - "!hr_payroll"
 
 ---
 ONLY:


### PR DESCRIPTION
The intent is to be able to exclude desired addons from a repository using this syntax:

```yml
some-repo:
  - "*"
  - "!addon_to_exclude"
```

@Yajo 