### PR TITLE
Disable the jessie-updates repo in old images

### DIFF
--- a/8.0.Dockerfile
+++ b/8.0.Dockerfile
@@ -37,7 +37,8 @@ ENV DB_FILTER=.* \
 
 # Other requirements and recommendations to run Odoo
 # See https://github.com/$ODOO_SOURCE/blob/$ODOO_VERSION/debian/control
-RUN apt-get update \
+RUN sed -Ei 's@(^deb http://deb.debian.org/debian jessie-updates main$)@#\1@' /etc/apt/sources.list \
+    && apt-get update \
     && apt-get -y upgrade \
     && apt-get install -y --no-install-recommends \
         python ruby-compass \


### PR DESCRIPTION

Images for Odoo v8-10, based on Debian 8, started to display errors when doing `apt-get update`.

The reason is that [the `jessie-updates` apt repo has been removed from apt mirrors](https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html).

I might consider updating the base OS, but for now IMHO the safest thing to do is to remove that repo.