### PR TITLE
Do not --upgrade when installing pip dependencies

### DIFF
--- a/lib/doodbalib/installer.py
+++ b/lib/doodbalib/installer.py
@@ -101,7 +101,7 @@ class NpmInstaller(Installer):
 
 
 class PipInstaller(Installer):
-    _install_command = ["pip", "install", "--upgrade", "--no-cache-dir", "-r"]
+    _install_command = ["pip", "install", "--no-cache-dir", "-r"]
 
     def requirements(self):
         """Pip will use its ``--requirements`` feature."""


### PR DESCRIPTION

It can lead to unexpected or unneeded upgrades, making downstream images bigger and less stable.

If you really need a newer (or older) version of any dependency than the one bundled (the one shipped from Odoo `requirements.txt` file), all you have to do is pin it in the scaffolding's `pip.txt` file.