### PR TITLE
Remove openupgradelib

### DIFF
--- a/11.0.Dockerfile
+++ b/11.0.Dockerfile
@@ -79,7 +79,6 @@ RUN pip install \
         astor \
         git+https://github.com/Tecnativa/click-odoo-contrib.git@update-parallel-db-lock-watcher#egg=click-odoo-contrib \
         git-aggregator \
-        openupgradelib \
         pg_activity \
         ptvsd \
         pudb \

--- a/12.0.Dockerfile
+++ b/12.0.Dockerfile
@@ -74,7 +74,6 @@ RUN pip install \
         astor \
         git+https://github.com/Tecnativa/click-odoo-contrib.git@update-parallel-db-lock-watcher#egg=click-odoo-contrib \
         git-aggregator \
-        openupgradelib \
         pg_activity \
         ptvsd \
         pudb \

--- a/8.0.Dockerfile
+++ b/8.0.Dockerfile
@@ -83,7 +83,6 @@ WORKDIR /opt/odoo
 RUN pip install \
         git+https://github.com/Tecnativa/click-odoo-contrib.git@update-parallel-db-lock-watcher#egg=click-odoo-contrib \
         git-aggregator \
-        openupgradelib \
         ptvsd \
         pudb \
         virtualenv \


### PR DESCRIPTION
Being practical, most of the time you need to install this library from git master.

Since https://github.com/Tecnativa/doodba/pull/213 adding [the corresponding line][1] to the scaffolding didn't actually install the version from master. The pip requirements file doesn't have a way to force updating a dependency when it is already installed from git.

It seems the easiest way to fix the situation is to remove `openupgradelib` from the base image. If you really need it, install it when building your subimage, either from pip or from git, however you want.

[1]: https://github.com/Tecnativa/doodba-scaffolding/blob/55a5e1b3ba65bec8604f3260e361f8b6a1d64b2e/odoo/custom/dependencies/pip.txt#L1