### PR TITLE
yaml.load security warning

### DIFF
--- a/bin/autoaggregate
+++ b/bin/autoaggregate
@@ -84,7 +84,7 @@ def missing_repos_config():
     # Find the repositories defined by hand
     try:
         with open(REPOS_YAML) as yaml_file:
-            for doc in yaml.load_all(yaml_file):
+            for doc in yaml.safe_load_all(yaml_file):
                 for repo in doc:
                     defined.add(os.path.abspath(os.path.join(SRC_DIR, repo)))
     except (IOError, AttributeError):
@@ -92,7 +92,7 @@ def missing_repos_config():
     # Find the repositories that should be present
     try:
         with open(ADDONS_YAML) as yaml_file:
-            for doc in yaml.load_all(yaml_file):
+            for doc in yaml.safe_load_all(yaml_file):
                 for repo in doc:
                     if repo in {PRIVATE, CORE, "ONLY"}:
                         continue


### PR DESCRIPTION
I'm gettings warnings when running setup-devel:
/usr/local/bin/autoaggregate:87: YAMLLoadWarning: calling yaml.load_all() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  for doc in yaml.load_all(yaml_file):
/usr/local/bin/autoaggregate:95: YAMLLoadWarning: calling yaml.load_all() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  for doc in yaml.load_all(yaml_file):

Looks a lot like #209 

BTW, Thanks ffor a GREAT project!