### PR TITLE
Filter db when testing addons

### DIFF
--- a/bin/addons
+++ b/bin/addons
@@ -104,5 +104,10 @@ else:
     command = ["odoo", "--stop-after-init", "--{}".format(args.action), addons]
     if args.test:
         command += ["--test-enable", "--workers", "0"]
+        if os.environ.get("PGDATABASE"):
+            command += [
+                "--db-filter",
+                u"^{}$".format(os.environ.get("PGDATABASE")),
+            ]
     logger.info("Executing %s", " ".join(command))
     check_call(command)


### PR DESCRIPTION

[In Odoo v12, tours do not know the database being used](https://github.com/odoo/odoo/issues/32687).

This is a simple workaround that lets us keep on working in v12 as before, and should be backwards compatible.

The fix is to add `--db-filter "^$PGDATABASE$"` to the command.

This can be rolled back when fixed upstream.