### PR TITLE
Include ffmpeg in v12

### DIFF
--- a/12.0.Dockerfile
+++ b/12.0.Dockerfile
@@ -41,6 +41,7 @@ RUN apt-get -qq update \
     && apt-get -yqq upgrade \
     && apt-get install -yqq --no-install-recommends \
         chromium \
+        ffmpeg \
         fonts-liberation2 \
         gettext-base \
         gnupg2 \


### PR DESCRIPTION

Odoo v12 supports logging a screencast of failed tours when `ffmpeg` is present and `--logfile` is supplied.

Obviously, including `ffmpeg` here. Screencasts everywhere! 📹