### PR TITLE
Smarter, less strict, config generator

### DIFF
--- a/11.0.Dockerfile
+++ b/11.0.Dockerfile
@@ -103,7 +103,7 @@ RUN python -m venv --system-site-packages /qa/venv \
         flake8 \
         pylint-odoo \
         six \
-    && npm install --loglevel error --prefix /qa eslint \
+    && npm install --loglevel error --prefix /qa 'eslint@<6' \
     && deactivate \
     && mkdir -p /qa/artifacts \
     && git clone --depth 1 $MQT /qa/mqt

--- a/8.0.Dockerfile
+++ b/8.0.Dockerfile
@@ -106,7 +106,7 @@ RUN virtualenv --system-site-packages /qa/venv \
         flake8 \
         pylint-odoo \
         six \
-    && npm install --loglevel error --prefix /qa eslint \
+    && npm install --loglevel error --prefix /qa 'eslint@<6' \
     && deactivate \
     && mkdir -p /qa/artifacts \
     && git clone --depth 1 $MQT /qa/mqt

--- a/bin/config-generate
+++ b/bin/config-generate
@@ -1,9 +1,51 @@
-#!/bin/bash
-# Generate Odoo server configuration from templates
-set -e
-src="/opt/odoo/common/conf.d/* /opt/odoo/custom/conf.d/*"
-log INFO Merging $(ls $src | wc -l) configuration files in $OPENERP_SERVER
-conf=$(cat $src | envsubst)
-log DEBUG "Resulting configuration:
-$conf"
-echo "$conf" > $OPENERP_SERVER
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Generate Odoo server configuration from templates"""
+
+import os
+from contextlib import closing
+from doodbalib import logger
+from string import Template
+
+try:
+    # Python 2, where io.StringIO fails because it is unicode-only
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
+try:
+    from configparser import RawConfigParser
+    parser = RawConfigParser(strict=False)
+except ImportError:
+    # Python 2, where strict=True doesn't exist
+    from ConfigParser import RawConfigParser
+    parser = RawConfigParser()
+
+ODOO_VERSION = os.environ.get("ODOO_VERSION")
+TARGET_FILE = os.environ.get("OPENERP_SERVER", "/opt/odoo/auto/odoo.conf")
+if ODOO_VERSION not in {"8.0", "9.0"}:
+    TARGET_FILE = os.environ.get("ODOO_RC", TARGET_FILE)
+CONFIG_DIRS = ("/opt/odoo/common/conf.d", "/opt/odoo/custom/conf.d")
+CONFIG_FILES = []
+
+# Read all configuraiton files found in those folders
+logger.info("Merging found configuration files in %s", TARGET_FILE)
+for dir_ in CONFIG_DIRS:
+    try:
+        for file_ in os.listdir(dir_):
+            parser.read(os.path.join(dir_, file_))
+    except OSError:  # TODO Use FileNotFoundError when we drop python 2
+        continue
+
+# Write it to a memory string object
+with closing(StringIO()) as resultfp:
+    parser.write(resultfp)
+    resultfp.seek(0)
+    # Obtain the config string
+    result = resultfp.read()
+    # Expand environment variables found within
+    result = Template(result).substitute(os.environ)
+    logger.debug("Resulting configuration:\n%s", result)
+    # Write it to destination
+    with open(TARGET_FILE, "w") as targetfp:
+        targetfp.write(result)

--- a/conf.d/10-addons.conf
+++ b/conf.d/10-addons.conf
@@ -1,2 +1,3 @@
+[options]
 ; Addons in priority order: private, then other repos, then base Odoo
 addons_path = /opt/odoo/auto/addons

--- a/conf.d/20-database.conf
+++ b/conf.d/20-database.conf
@@ -1,3 +1,4 @@
+[options]
 ; Database settings, matching defaults when you execute `psql`
 db_user = $PGUSER
 db_password = $PGPASSWORD

--- a/conf.d/30-proxy-mode.conf
+++ b/conf.d/30-proxy-mode.conf
@@ -1,2 +1,3 @@
+[options]
 ; Normally Odoo should run behind a proxy
 proxy_mode = $PROXY_MODE

--- a/conf.d/40-smtp.conf
+++ b/conf.d/40-smtp.conf
@@ -1,3 +1,4 @@
+[options]
 ; Prepared to link with https://hub.docker.com/r/tecnativa/postfix-relay
 smtp_server = $SMTP_SERVER
 smtp_port = $SMTP_PORT

--- a/conf.d/50-demo-data.conf
+++ b/conf.d/50-demo-data.conf
@@ -1,2 +1,3 @@
+[options]
 ; Useful for testing, useless for production, disabled by default
 without_demo = $WITHOUT_DEMO

--- a/tests/scaffoldings/settings/custom/conf.d/00-defaults.conf
+++ b/tests/scaffoldings/settings/custom/conf.d/00-defaults.conf
@@ -1,0 +1,3 @@
+[options]
+# Simulate a default value of 1000 MiB
+limit_memory_soft = 1048576000

--- a/tests/scaffoldings/settings/custom/conf.d/10-custom.conf
+++ b/tests/scaffoldings/settings/custom/conf.d/10-custom.conf
@@ -1,0 +1,3 @@
+[options]
+# Customize the default to 2000 MiB
+limit_memory_soft = 2097152000

--- a/tests/scaffoldings/settings/custom/scripts/test_settings.py
+++ b/tests/scaffoldings/settings/custom/scripts/test_settings.py
@@ -6,6 +6,7 @@ except ImportError:
 
 
 assert config.get("email_from") == "test@example.com"
+assert config.get("limit_memory_soft") == 2097152000
 assert config.get("smtp_password") is False
 assert config.get("smtp_port") == 1025
 assert config.get("smtp_server") == "mailhog"


### PR DESCRIPTION
Before Odoo v11, Odoo wasn't so strict when reading configuration. Since v11, where Python 3 started to be used, it used the new default `strict=True` mode to read configuration files.

The strict mode forbids section and option repetitions. Although that seems legit for most apps (even Odoo itself), in Doodba we provide a set of predefined defaults that downstream scaffoldings should be able to override.

To allow such behavior, now the script that generates the final config will do it in `strict=False` mode, but will remove duplicates and just use the latest option defined, effectively producing a strict config file out of a collection of non-strict configs.

Of course, options until now are respected, like output of result while in `LOG_LEVEL=DEBUG` or env variable substitution.

Full power! 💪