### PR TITLE
[FIX] add configs in sorted order

### DIFF
--- a/bin/config-generate
+++ b/bin/config-generate
@@ -32,7 +32,7 @@ CONFIG_FILES = []
 logger.info("Merging found configuration files in %s", TARGET_FILE)
 for dir_ in CONFIG_DIRS:
     try:
-        for file_ in os.listdir(dir_):
+        for file_ in sorted(os.listdir(dir_)):
             parser.read(os.path.join(dir_, file_))
     except OSError:  # TODO Use FileNotFoundError when we drop python 2
         continue


### PR DESCRIPTION
configs should be read in order:
00-something.conf should be parsed before 10-another_thing.conf

fixes https://github.com/Tecnativa/doodba/issues/230