### PR TITLE
Remove unsafe call

### DIFF
--- a/bin/autoaggregate
+++ b/bin/autoaggregate
@@ -121,12 +121,7 @@ def missing_repos_config():
 
 # Aggregate user-specified repos
 if os.path.isfile(REPOS_YAML):
-    # HACK https://github.com/acsone/git-aggregator/pull/23
-    has_contents = True
-    with open(REPOS_YAML) as repos_file:
-        has_contents = yaml.load(repos_file)
-    if has_contents:
-        aggregate(REPOS_YAML)
+    aggregate(REPOS_YAML)
 
 # Aggregate unspecified repos
 missing_config = missing_repos_config()


### PR DESCRIPTION
This chunk of code was warning:

```
/usr/local/bin/autoaggregate:127: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  has_contents = yaml.load(repos_file)
```

Since it was just a workaround for https://github.com/acsone/git-aggregator/pull/23 and that's fixed already, I can remove it and fix the warning all with one shot.