### PR TITLE
Fix wrong location of odoo script target

### DIFF
--- a/build.d/700-odoo-install
+++ b/build.d/700-odoo-install
@@ -22,16 +22,14 @@ if [ "$PIP_INSTALL_ODOO" == true ]; then
 else
     log WARNING Blindly symlinking odoo executable
     bin=$src/odoo-bin
-    if [ -x $src/openerp-server ]; then
+    # Cannot check for scripts existence and link all: they probably do not
+    # exist yet at build time! Just check Odoo version and act properly.
+    if [ "$ODOO_VERSION" == "7.0" ]; then
         bin=$src/openerp-server
-        ln -s $src/openerp-server /usr/local/bin
-    fi
-    if [ -x $src/openerp-gevent ]; then
-        ln -s $src/openerp-gevent /usr/local/bin
-    fi
-    if [ -x $src/odoo.py ]; then
+        ln -s /opt/odoo/custom/src/odoo/openerp-server /usr/local/bin/
+    elif [ "$ODOO_VERSION" == "8.0" -o "$ODOO_VERSION" == "9.0" ]; then
         bin=$src/odoo.py
-        ln -s $src/odoo.py /usr/local/bin
+        ln -s /opt/odoo/custom/src/odoo/openerp-{gevent,server} /usr/local/bin/
     fi
     ln -s $bin $dst
 fi

--- a/tests/scaffoldings/uids_1001/docker-compose.yaml
+++ b/tests/scaffoldings/uids_1001/docker-compose.yaml
@@ -6,6 +6,7 @@ services:
       args:
         COMPILE: "false"
         ODOO_VERSION: $ODOO_MINOR
+        PIP_INSTALL_ODOO: "false"
         WITHOUT_DEMO: "false"
         UID: 1001
         GID: 1002


### PR DESCRIPTION
The odoo script must always point to the right executable in whatever odoo version you're using.

That's how it works for test and prod environments, but 89360140728b2e09c97cbd5bb7daae6ff581fbd0 introduced a regression on this matter for devel environment.

The main problem is that it was trying to be "smarter" by checking script existence, while at build time, in devel, those scripts still do not exist, so it always resolved to latest version (which uses `odoo-bin`) and broke older versions (those that use `openerp-server` or `odoo.py`).

I made it dumber-but-working again, and added a little comment to avoid future me to try to "fix" this again.