### PR TITLE
Add -l option to useradd

### DIFF
--- a/11.0.Dockerfile
+++ b/11.0.Dockerfile
@@ -192,7 +192,7 @@ ONBUILD ARG GID=1000
 
 # Enable Odoo user and filestore
 ONBUILD RUN groupadd -g $GID odoo \
-    && useradd -md /home/odoo -s /bin/false -u $UID -g $GID odoo \
+    && useradd -l -md /home/odoo -s /bin/false -u $UID -g $GID odoo \
     && mkdir -p /var/lib/odoo \
     && chown -R odoo:odoo /var/lib/odoo /qa/artifacts \
     && chmod a=rwX /qa/artifacts \

--- a/12.0.Dockerfile
+++ b/12.0.Dockerfile
@@ -188,7 +188,7 @@ ONBUILD ARG GID=1000
 
 # Enable Odoo user and filestore
 ONBUILD RUN groupadd -g $GID odoo \
-    && useradd -md /home/odoo -s /bin/false -u $UID -g $GID odoo \
+    && useradd -l -md /home/odoo -s /bin/false -u $UID -g $GID odoo \
     && mkdir -p /var/lib/odoo \
     && chown -R odoo:odoo /var/lib/odoo /qa/artifacts \
     && chmod a=rwX /qa/artifacts \

--- a/13.0.Dockerfile
+++ b/13.0.Dockerfile
@@ -196,7 +196,7 @@ ONBUILD ARG GID=1000
 
 # Enable Odoo user and filestore
 ONBUILD RUN groupadd -g $GID odoo \
-    && useradd -md /home/odoo -s /bin/false -u $UID -g $GID odoo \
+    && useradd -l -md /home/odoo -s /bin/false -u $UID -g $GID odoo \
     && mkdir -p /var/lib/odoo \
     && chown -R odoo:odoo /var/lib/odoo /qa/artifacts \
     && chmod a=rwX /qa/artifacts \

--- a/8.0.Dockerfile
+++ b/8.0.Dockerfile
@@ -190,7 +190,7 @@ ONBUILD ARG GID=1000
 
 # Enable Odoo user and filestore
 ONBUILD RUN groupadd -g $GID odoo \
-    && useradd -md /home/odoo -s /bin/false -u $UID -g $GID odoo \
+    && useradd -l -md /home/odoo -s /bin/false -u $UID -g $GID odoo \
     && mkdir -p /var/lib/odoo \
     && chown -R odoo:odoo /var/lib/odoo /qa/artifacts\
     && chmod a=rwX /qa/artifacts \


### PR DESCRIPTION
I currently face up to an issue with current docker image.
My local user is freeipa user (not in /etc/passwd).

The fix is to add an option to useradd.
the -l flag of useradd prevents adding the user to the lastlog and faillog databases. Then no issue with overlay2 and lastlog file.

cf https://www.reddit.com/r/docker/comments/9jy0au/weird_behavior_while_creating_user_in_dockerfile/