### PR TITLE
Skip files in external repos

### DIFF
--- a/lib/doodbalib/__init__.py
+++ b/lib/doodbalib/__init__.py
@@ -122,6 +122,8 @@ def addons_config(filtered=True, strict=False):
                 logger.debug("Skipping unexpandable glob '%s'", full_glob)
                 continue
             for addon in found:
+                if not os.path.isdir(addon):
+                    continue
                 manifests = (os.path.join(addon, m) for m in MANIFESTS)
                 if not any(os.path.isfile(m) for m in manifests):
                     missing_manifest.add(addon)


### PR DESCRIPTION
With this patch, if a repo has a README file (for example) and it's included as `*`, it will not fail saying that addon is missing.

@Tecnativa TT20969