### PR TITLE
Document shell_command_after to merge diffs

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,6 +556,9 @@ This example merges [several sources][`odoo`]:
   merges:
     - ocb $ODOO_VERSION
     - odoo refs/pull/13635/head
+  shell_command_after:
+    # Useful to merge a diff when there's no git history correlation
+    - curl -sSL https://github.com/odoo/odoo/pull/37187.diff | patch -fp1
 ```
 
 ### [`odoo`](https://www.odoo.com/documentation/10.0/reference/cmdline.html)


### PR DESCRIPTION
This is a useful case for Doodba users, where possibly you want to pre-merge a patch done for Odoo v11 into your Odoo v13 deployment, before Odoo approves it.

Using just git branches is not much helpful in this case because no git history is shared, so conflicts would arise always.

In fact, this might be the best way to apply merges *always*. That's to be investigated.

Upstream support for diffs and patches is being tracked in https://github.com/acsone/git-aggregator/issues/34, but in the mean time this option is available today, so it's better to make it more obvious.

@Tecnativa TT19951