### PR TITLE
Fix dependency inclusion and exclusion detection

### DIFF
--- a/bin/addons
+++ b/bin/addons
@@ -94,7 +94,8 @@ try:
         core_ok = args.core and repo == CORE
         extra_ok = args.extra and repo not in {CORE, PRIVATE}
         private_ok = args.private and repo == PRIVATE
-        if private_ok or core_ok or extra_ok:
+        manual_ok = addon in addons
+        if private_ok or core_ok or extra_ok or manual_ok:
             addon_path = os.path.join(SRC_DIR, repo, addon)
             manifest = {}
             for manifest_name in MANIFESTS:
@@ -116,6 +117,7 @@ except AddonsConfigError as error:
 # Use dependencies instead, if requested
 if args.dependencies:
     addons = dependencies - addons
+addons -= without
 
 # Do the required action
 if not addons:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -105,6 +105,22 @@ class ScaffoldingCase(unittest.TestCase):
                 ("bash", "-c", "addons list -c | grep ,crm,"),
                 # absent_addon is missing and should fail
                 ("bash", "-c", "! addons list -px"),
+                # Test addon inclusion, exclusion, dependencies...
+                (
+                    "bash",
+                    "-xc",
+                    'test "$(addons list -dw private_addon)" == base,dummy_addon,website',
+                ),
+                (
+                    "bash",
+                    "-xc",
+                    'test "$(addons list -dwprivate_addon -Wwebsite)" == base,dummy_addon',
+                ),
+                (
+                    "bash",
+                    "-xc",
+                    'test "$(addons list -dw private_addon -W dummy_addon)" == base,website',
+                ),
             )
             self.compose_test(
                 project_dir,


### PR DESCRIPTION
Before this patch:

- When an addon was included with `--with`, its dependencies were not detected.
- When an addon was excluded with `--without` but it was a dependency of another addon that was included, it ended up in the final list (although explicitly excluded).

TT20969 TT20963