### PR TITLE
Master allow duplicate gid

### DIFF
--- a/11.0.Dockerfile
+++ b/11.0.Dockerfile
@@ -191,7 +191,7 @@ ONBUILD ARG UID=1000
 ONBUILD ARG GID=1000
 
 # Enable Odoo user and filestore
-ONBUILD RUN groupadd -g $GID odoo \
+ONBUILD RUN groupadd -g $GID odoo -o \
     && useradd -l -md /home/odoo -s /bin/false -u $UID -g $GID odoo \
     && mkdir -p /var/lib/odoo \
     && chown -R odoo:odoo /var/lib/odoo /qa/artifacts \

--- a/12.0.Dockerfile
+++ b/12.0.Dockerfile
@@ -187,7 +187,7 @@ ONBUILD ARG UID=1000
 ONBUILD ARG GID=1000
 
 # Enable Odoo user and filestore
-ONBUILD RUN groupadd -g $GID odoo \
+ONBUILD RUN groupadd -g $GID odoo -o \
     && useradd -l -md /home/odoo -s /bin/false -u $UID -g $GID odoo \
     && mkdir -p /var/lib/odoo \
     && chown -R odoo:odoo /var/lib/odoo /qa/artifacts \

--- a/13.0.Dockerfile
+++ b/13.0.Dockerfile
@@ -197,7 +197,7 @@ ONBUILD ARG UID=1000
 ONBUILD ARG GID=1000
 
 # Enable Odoo user and filestore
-ONBUILD RUN groupadd -g $GID odoo \
+ONBUILD RUN groupadd -g $GID odoo -o \
     && useradd -l -md /home/odoo -s /bin/false -u $UID -g $GID odoo \
     && mkdir -p /var/lib/odoo \
     && chown -R odoo:odoo /var/lib/odoo /qa/artifacts \

--- a/8.0.Dockerfile
+++ b/8.0.Dockerfile
@@ -189,7 +189,7 @@ ONBUILD ARG UID=1000
 ONBUILD ARG GID=1000
 
 # Enable Odoo user and filestore
-ONBUILD RUN groupadd -g $GID odoo \
+ONBUILD RUN groupadd -g $GID odoo -o \
     && useradd -l -md /home/odoo -s /bin/false -u $UID -g $GID odoo \
     && mkdir -p /var/lib/odoo \
     && chown -R odoo:odoo /var/lib/odoo /qa/artifacts\

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -424,6 +424,35 @@ class ScaffoldingCase(unittest.TestCase):
                 ),
             )
 
+    def test_uids_mac_os(self):
+        """tests if we can build an image with a custom uid and gid of odoo"""
+        uids_dir = join(SCAFFOLDINGS_DIR, "uids_mac_os")
+        for sub_env in matrix():
+            self.compose_test(
+                uids_dir,
+                sub_env,
+                # verify that odoo user has the given ids
+                ("bash", "-c", 'test "$(id -u)" == "501"'),
+                ("bash", "-c", 'test "$(id -g)" == "20"'),
+                ("bash", "-c", 'test "$(id -u -n)" == "odoo"'),
+                # all those directories need to belong to odoo (user or group odoo/dialout)
+                (
+                    "bash",
+                    "-c",
+                    'test "$(stat -c \'%U:%g\' /var/lib/odoo)" == "odoo:20"',
+                ),
+                (
+                    "bash",
+                    "-c",
+                    'test "$(stat -c \'%U:%g\' /opt/odoo/auto/addons)" == "root:20"',
+                ),
+                (
+                    "bash",
+                    "-c",
+                    'test "$(stat -c \'%U:%g\' /opt/odoo/custom/src)" == "root:20"',
+                ),
+            )
+
     def test_default_uids(self):
         uids_dir = join(SCAFFOLDINGS_DIR, "uids_default")
         for sub_env in matrix():

--- a/tests/scaffoldings/uids_mac_os/Dockerfile
+++ b/tests/scaffoldings/uids_mac_os/Dockerfile
@@ -1,0 +1,2 @@
+ARG ODOO_VERSION
+FROM tecnativa/doodba:${ODOO_VERSION}-onbuild

--- a/tests/scaffoldings/uids_mac_os/docker-compose.yaml
+++ b/tests/scaffoldings/uids_mac_os/docker-compose.yaml
@@ -1,0 +1,33 @@
+version: "2.1"
+services:
+  odoo:
+    build:
+      context: ./
+      args:
+        COMPILE: "false"
+        ODOO_VERSION: $ODOO_MINOR
+        PIP_INSTALL_ODOO: "false"
+        WITHOUT_DEMO: "false"
+        UID: 501
+        GID: 20
+
+    tty: true
+    depends_on:
+      - db
+    environment:
+      PYTHONOPTIMIZE: ""
+      UNACCENT: "false"
+    volumes:
+      - filestore:/var/lib/odoo:z
+
+  db:
+    image: postgres:${DB_VERSION}-alpine
+    environment:
+      POSTGRES_USER: odoo
+      POSTGRES_PASSWORD: odoopassword
+    volumes:
+      - db:/var/lib/postgresql/data:z
+
+volumes:
+  db:
+  filestore:


### PR DESCRIPTION
On macOS the default UID and GID are 501 and 20. The gid 20 conflicts with debians dialout group in doodba. When building on macOS one gets a message like this:
```
groupadd: GID '20' already exists
ERROR: Service 'odoo' failed to build: The command '/bin/sh -c groupadd -g $GID odoo     && useradd -l -md /home/odoo -s /bin/false -u $UID -g $GID odoo     && mkdir -p /var/lib/odoo    && chown -R odoo:odoo /var/lib/odoo /qa/artifacts     && chmod a=rwX /qa/artifacts     && sync' returned a non-zero code: 4
```

![Screenshot 2020-01-09 at 12 17 53](https://user-images.githubusercontent.com/38032588/72146197-4001dc80-339c-11ea-9463-b2deb1f848cd.png)


We fixed this by allowing the added group odoo having the same gid as any existing group and added a test for building with default macOS ids.

A side effect is that if you check the group name of a directory in the container it will return the primary group name (dialout for 20) not odoo as group name. But this fix seems less complicated than deleting the primary group, adding odoo and then adding the primary group as secondary name again.

This should not affect users not having such low gid's.

Info @wt-io-it