### PR TITLE
Change no addons found exit code to 4

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
   "python.autoComplete.extraPaths": ["./lib", "./tests"],
   "editor.formatOnSaveTimeout": 1000,
   "python.formatting.provider": "black",
+  "python.formatting.blackArgs": [],
   "python.linting.flake8Args": ["--max-line-length=88"],
   "python.linting.flake8Enabled": true,
   "python.linting.pylintEnabled": true,

--- a/bin/addons
+++ b/bin/addons
@@ -19,6 +19,9 @@ from doodbalib import (
     logger,
 )
 
+# Exit codes
+EXIT_NO_ADDONS = 0x4
+
 # Define CLI options
 parser = ArgumentParser(description="Install addons in current environment")
 parser.add_argument(
@@ -127,7 +130,7 @@ addons -= without
 # Do the required action
 if not addons:
     print("No addons found", file=sys.stderr)
-    sys.exit(2)
+    sys.exit(EXIT_NO_ADDONS)
 addons = args.separator.join(sorted(addons))
 if args.action == "list":
     print(addons)


### PR DESCRIPTION
It turns out that an arguments syntax error exits with 0x2, which is the same exit code I chose to indicate there are no addons. This way, there's no way to know if there was a real error or there were simply no addons found.

So I change the exit code for addons not found to 0x4.

https://github.com/Tecnativa/doodba-qa/pull/17 won't be able to complete without this patch.

TT21246