### PR TITLE
fix db_filter typo in conf.d/20-database.conf

### DIFF
--- a/conf.d/20-database.conf
+++ b/conf.d/20-database.conf
@@ -5,5 +5,5 @@ db_password = $PGPASSWORD
 db_host = $PGHOST
 db_port = $PGPORT
 db_name = $PGDATABASE
-dbfilter = $DB_FILTER
+db_filter = $DB_FILTER
 list_db = $LIST_DB

--- a/tests/scaffoldings/settings/custom/scripts/test_settings.py
+++ b/tests/scaffoldings/settings/custom/scripts/test_settings.py
@@ -13,4 +13,4 @@ assert config.get("smtp_port") == 1025
 assert config.get("smtp_server") == "mailhog"
 assert config.get("smtp_ssl") is False
 assert config.get("smtp_user") is False
-assert config.get("dbfilter") == ".*"
+assert config.get("db_filter") == ".*"


### PR DESCRIPTION
apologies, I haven't tested this fully. 

setting DB_FILTER="^%d$" in .env didn't work for me.

I manually edited auto/odoo.conf in the container with nano and changed the line with dbfilter = to db_filter = and restart the container and it worked. I think this patch should fix it but it's not tested.
