### PR TITLE
fix: wdb for Odoo v9.0 needs simplejson installed to work

### DIFF
--- a/8.0.Dockerfile
+++ b/8.0.Dockerfile
@@ -81,6 +81,7 @@ RUN pip install \
         pudb \
         virtualenv \
         wdb \
+        simplejson \
     && sync
 COPY bin-deprecated/* bin/* /usr/local/bin/
 COPY lib/doodbalib /usr/local/lib/python2.7/dist-packages/doodbalib


### PR DESCRIPTION
When running Odoo v9 and using:
```
import wdb
wdb.set_trace()
```

wdb tries to import simplejson which is not packaged into the base image for Odoo v9. So wdb was only working if simplejson was added in the scaffolding. Ideally wdb should work out of the box also for Odoo v9.

Stacktrace from when i discovered this issue while trying to get #275
```
odoo_1                    |   File "/opt/odoo/custom/src/odoo/addons/website/models/ir_http.py", line 116, in _dispatch
odoo_1                    |     self._geoip_setup_resolver()
odoo_1                    |   File "/opt/odoo/custom/src/odoo/addons/website/models/ir_http.py", line 75, in _geoip_setup_resolver
odoo_1                    |     import wdb
odoo_1                    |   File "/usr/local/lib/python2.7/dist-packages/wdb/__init__.py", line 31, in <module>
odoo_1                    |     from ._compat import (
odoo_1                    |   File "/usr/local/lib/python2.7/dist-packages/wdb/_compat.py", line 10, in <module>
odoo_1                    |     from simplejson import loads, dumps, JSONEncoder, JSONDecodeError
odoo_1                    | ImportError: No module named simplejson
```