### PR TITLE
Update Python 3 version in v11 and v12

### DIFF
--- a/11.0.Dockerfile
+++ b/11.0.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5-stretch AS base
+FROM python:3.7-stretch AS base
 
 EXPOSE 8069 8072
 
@@ -80,9 +80,9 @@ RUN pip install \
         wdb \
     && sync
 COPY bin-deprecated/* bin/* /usr/local/bin/
-COPY lib/doodbalib /usr/local/lib/python3.5/site-packages/doodbalib
-RUN ln -s /usr/local/lib/python3.5/site-packages/doodbalib \
-    /usr/local/lib/python3.5/site-packages/odoobaselib
+COPY lib/doodbalib /usr/local/lib/python3.7/site-packages/doodbalib
+RUN ln -s /usr/local/lib/python3.7/site-packages/doodbalib \
+    /usr/local/lib/python3.7/site-packages/odoobaselib
 COPY build.d common/build.d
 COPY conf.d common/conf.d
 COPY entrypoint.d common/entrypoint.d
@@ -90,7 +90,7 @@ RUN mkdir -p auto/addons custom/src/private \
     && ln /usr/local/bin/direxec common/entrypoint \
     && ln /usr/local/bin/direxec common/build \
     && chmod -R a+rx common/entrypoint* common/build* /usr/local/bin \
-    && chmod -R a+rX /usr/local/lib/python3.5/site-packages/doodbalib \
+    && chmod -R a+rX /usr/local/lib/python3.7/site-packages/doodbalib \
     && sync
 
 # Doodba-QA dependencies in a separate virtualenv
@@ -119,7 +119,7 @@ RUN debs="libldap2-dev libsasl2-dev" \
     && apt-get install -yqq --no-install-recommends $debs \
     && pip install \
         -r https://raw.githubusercontent.com/$ODOO_SOURCE/$ODOO_VERSION/requirements.txt \
-    && (python3 -m compileall -q /usr/local/lib/python3.5/ || true) \
+    && (python3 -m compileall -q /usr/local/lib/python3.7/ || true) \
     && apt-get purge -yqq $debs \
     && rm -Rf /var/lib/apt/lists/* /tmp/*
 

--- a/12.0.Dockerfile
+++ b/12.0.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5-stretch AS base
+FROM python:3.7-stretch AS base
 
 EXPOSE 8069 8072
 
@@ -76,7 +76,7 @@ RUN pip install \
         wdb \
     && sync
 COPY bin-deprecated/* bin/* /usr/local/bin/
-COPY lib/doodbalib /usr/local/lib/python3.5/site-packages/doodbalib
+COPY lib/doodbalib /usr/local/lib/python3.7/site-packages/doodbalib
 COPY build.d common/build.d
 COPY conf.d common/conf.d
 COPY entrypoint.d common/entrypoint.d
@@ -84,7 +84,7 @@ RUN mkdir -p auto/addons custom/src/private \
     && ln /usr/local/bin/direxec common/entrypoint \
     && ln /usr/local/bin/direxec common/build \
     && chmod -R a+rx common/entrypoint* common/build* /usr/local/bin \
-    && chmod -R a+rX /usr/local/lib/python3.5/site-packages/doodbalib \
+    && chmod -R a+rX /usr/local/lib/python3.7/site-packages/doodbalib \
     && sync
 
 # Doodba-QA dependencies in a separate virtualenv
@@ -115,7 +115,7 @@ RUN debs="libldap2-dev libsasl2-dev" \
         -r https://raw.githubusercontent.com/$ODOO_SOURCE/$ODOO_VERSION/requirements.txt \
         phonenumbers \
         'websocket-client~=0.53' \
-    && (python3 -m compileall -q /usr/local/lib/python3.5/ || true) \
+    && (python3 -m compileall -q /usr/local/lib/python3.7/ || true) \
     && apt-get purge -yqq $debs \
     && rm -Rf /var/lib/apt/lists/* /tmp/*
 


### PR DESCRIPTION
Python 3.5 is flawed. It affects Odoo badly as shown in https://github.com/odoo/odoo/issues/20158. Odoo claims to have included a workaround for that in their code, but that simply doesn't work according to real world tests.

The only fix is to update Python version, so here's the update.

This patch reverts #199 for v11 and v12.

@Tecnativa TT21841