### PR TITLE
add --with to addons command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1092,11 +1092,11 @@ In development mode odoo restarts by itself thanks to `--dev=reload` option.
 ```bash
 modules=addon1,addon2
 # Install their dependencies first
-docker-compose run --rm odoo addons init --dependencies $modules
+docker-compose run --rm odoo addons init --dependencies --with $modules
 # Test them at install
-docker-compose run --rm odoo addons init --test $modules
+docker-compose run --rm odoo addons init --test --with $modules
 # Test them again at update
-docker-compose run --rm odoo addons update --test $modules
+docker-compose run --rm odoo addons update --test --with $modules
 ```
 
 \* Note: This replaces the old deprecated `unittest` script.


### PR DESCRIPTION
command "addons" doesn't accept modules as positional arguments.

Example:

$ docker-compose run --rm odoo addons init --test web_debranding


doodba INFO: Executing addons init --test web_debranding
usage: addons [-h] [-c] [-d] [-e] [-f] [-i] [-n] [-p] [-s SEPARATOR] [-t] [-x]
              [-w WITH_] [-W WITHOUT]
              {init,update,list}
addons: error: unrecognized arguments: web_debranding