### PR TITLE
Add python lib firebase_admin for standard odoo module 

### DIFF
--- a/13.0.Dockerfile
+++ b/13.0.Dockerfile
@@ -127,6 +127,7 @@ RUN build_deps=" \
         astor \
         git-aggregator \
         click-odoo-contrib \
+        firebase_admin \
         pg_activity \
         phonenumbers \
         plumbum \


### PR DESCRIPTION
social_push_notification is a standard odoo module that has this external dependency.

Not sure what the policy is here since odoo does not provide it in the requirements.txt themselves. I thought this might be helpful as it supports a standard module.