### PR TITLE
Revert "Update Python 3 version in v11 and v12"

### DIFF
--- a/11.0.Dockerfile
+++ b/11.0.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-stretch AS base
+FROM python:3.5-stretch AS base
 
 EXPOSE 8069 8072
 
@@ -88,9 +88,9 @@ RUN pip install \
         geoip2 \
     && sync
 COPY bin-deprecated/* bin/* /usr/local/bin/
-COPY lib/doodbalib /usr/local/lib/python3.7/site-packages/doodbalib
-RUN ln -s /usr/local/lib/python3.7/site-packages/doodbalib \
-    /usr/local/lib/python3.7/site-packages/odoobaselib
+COPY lib/doodbalib /usr/local/lib/python3.5/site-packages/doodbalib
+RUN ln -s /usr/local/lib/python3.5/site-packages/doodbalib \
+    /usr/local/lib/python3.5/site-packages/odoobaselib
 COPY build.d common/build.d
 COPY conf.d common/conf.d
 COPY entrypoint.d common/entrypoint.d
@@ -98,7 +98,7 @@ RUN mkdir -p auto/addons auto/geoip custom/src/private \
     && ln /usr/local/bin/direxec common/entrypoint \
     && ln /usr/local/bin/direxec common/build \
     && chmod -R a+rx common/entrypoint* common/build* /usr/local/bin \
-    && chmod -R a+rX /usr/local/lib/python3.7/site-packages/doodbalib \
+    && chmod -R a+rX /usr/local/lib/python3.5/site-packages/doodbalib \
     && mv /etc/GeoIP.conf /opt/odoo/auto/geoip/GeoIP.conf \
     && ln -s /opt/odoo/auto/geoip/GeoIP.conf /etc/GeoIP.conf \
     && sed -i 's/.*DatabaseDirectory .*$/DatabaseDirectory \/opt\/odoo\/auto\/geoip\//g' /opt/odoo/auto/geoip/GeoIP.conf \
@@ -130,7 +130,7 @@ RUN debs="libldap2-dev libsasl2-dev" \
     && apt-get install -yqq --no-install-recommends $debs \
     && pip install \
         -r https://raw.githubusercontent.com/$ODOO_SOURCE/$ODOO_VERSION/requirements.txt \
-    && (python3 -m compileall -q /usr/local/lib/python3.7/ || true) \
+    && (python3 -m compileall -q /usr/local/lib/python3.5/ || true) \
     && apt-get purge -yqq $debs \
     && rm -Rf /var/lib/apt/lists/* /tmp/*
 

--- a/12.0.Dockerfile
+++ b/12.0.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-stretch AS base
+FROM python:3.5-stretch AS base
 
 EXPOSE 8069 8072
 
@@ -84,7 +84,7 @@ RUN pip install \
         geoip2 \
     && sync
 COPY bin-deprecated/* bin/* /usr/local/bin/
-COPY lib/doodbalib /usr/local/lib/python3.7/site-packages/doodbalib
+COPY lib/doodbalib /usr/local/lib/python3.5/site-packages/doodbalib
 COPY build.d common/build.d
 COPY conf.d common/conf.d
 COPY entrypoint.d common/entrypoint.d
@@ -92,7 +92,7 @@ RUN mkdir -p auto/addons auto/geoip custom/src/private \
     && ln /usr/local/bin/direxec common/entrypoint \
     && ln /usr/local/bin/direxec common/build \
     && chmod -R a+rx common/entrypoint* common/build* /usr/local/bin \
-    && chmod -R a+rX /usr/local/lib/python3.7/site-packages/doodbalib \
+    && chmod -R a+rX /usr/local/lib/python3.5/site-packages/doodbalib \
     && mv /etc/GeoIP.conf /opt/odoo/auto/geoip/GeoIP.conf \
     && ln -s /opt/odoo/auto/geoip/GeoIP.conf /etc/GeoIP.conf \
     && sed -i 's/.*DatabaseDirectory .*$/DatabaseDirectory \/opt\/odoo\/auto\/geoip\//g' /opt/odoo/auto/geoip/GeoIP.conf \
@@ -126,7 +126,7 @@ RUN debs="libldap2-dev libsasl2-dev" \
         -r https://raw.githubusercontent.com/$ODOO_SOURCE/$ODOO_VERSION/requirements.txt \
         phonenumbers \
         'websocket-client~=0.53' \
-    && (python3 -m compileall -q /usr/local/lib/python3.7/ || true) \
+    && (python3 -m compileall -q /usr/local/lib/python3.5/ || true) \
     && apt-get purge -yqq $debs \
     && rm -Rf /var/lib/apt/lists/* /tmp/*
 

--- a/13.0.Dockerfile
+++ b/13.0.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim-buster AS base
+FROM python:3.6-slim-buster AS base
 
 EXPOSE 8069 8072
 
@@ -19,7 +19,7 @@ ENV DB_FILTER=.* \
     NODE_PATH=/usr/local/lib/node_modules:/usr/lib/node_modules \
     OPENERP_SERVER=/opt/odoo/auto/odoo.conf \
     PATH="/home/odoo/.local/bin:$PATH" \
-    PIP_NO_CACHE_DIR=1 \
+    PIP_NO_CACHE_DIR=0 \
     PTVSD_ARGS="--host 0.0.0.0 --port 6899 --wait --multiprocess" \
     PTVSD_ENABLE=0 \
     PUDB_RDB_HOST=0.0.0.0 \
@@ -67,7 +67,7 @@ RUN apt-get -qq update \
 
 WORKDIR /opt/odoo
 COPY bin/* /usr/local/bin/
-COPY lib/doodbalib /usr/local/lib/python3.7/site-packages/doodbalib
+COPY lib/doodbalib /usr/local/lib/python3.6/site-packages/doodbalib
 COPY build.d common/build.d
 COPY conf.d common/conf.d
 COPY entrypoint.d common/entrypoint.d
@@ -75,7 +75,7 @@ RUN mkdir -p auto/addons auto/geoip custom/src/private \
     && ln /usr/local/bin/direxec common/entrypoint \
     && ln /usr/local/bin/direxec common/build \
     && chmod -R a+rx common/entrypoint* common/build* /usr/local/bin \
-    && chmod -R a+rX /usr/local/lib/python3.7/site-packages/doodbalib \
+    && chmod -R a+rX /usr/local/lib/python3.6/site-packages/doodbalib \
     && mv /etc/GeoIP.conf /opt/odoo/auto/geoip/GeoIP.conf \
     && ln -s /opt/odoo/auto/geoip/GeoIP.conf /etc/GeoIP.conf \
     && sed -i 's/.*DatabaseDirectory .*$/DatabaseDirectory \/opt\/odoo\/auto\/geoip\//g' /opt/odoo/auto/geoip/GeoIP.conf \
@@ -115,6 +115,8 @@ RUN build_deps=" \
         libsasl2-dev \
         libtiff5-dev \
         libwebp-dev \
+        libxml2-dev \
+        libxslt-dev \
         tcl-dev \
         tk-dev \
         zlib1g-dev \
@@ -135,7 +137,7 @@ RUN build_deps=" \
         watchdog \
         wdb \
         geoip2 \
-    && (python3 -m compileall -q /usr/local/lib/python3.7/ || true) \
+    && (python3 -m compileall -q /usr/local/lib/python3.6/ || true) \
     && apt-get purge -yqq $build_deps \
     && apt-get autopurge -yqq \
     && rm -Rf /var/lib/apt/lists/* /tmp/*


### PR DESCRIPTION
This reverts commit dbaaa2782a2d00e093063ebee3478c1d4093def3 from https://github.com/Tecnativa/doodba/pull/290.

Also reverts v13 to oldest supported python version (3.6 per the docs).

@Tecnativa TT23435