### PR TITLE
Configure screenshots and screencasts dir

### DIFF
--- a/conf.d/00-base.conf
+++ b/conf.d/00-base.conf
@@ -3,3 +3,7 @@
 admin_passwd = $ADMIN_PASSWORD
 data_dir = /var/lib/odoo
 unaccent = $UNACCENT
+
+; Used in v13+ devel mode only
+screencasts = /opt/odoo/auto/test-artifacts
+screenshots = /opt/odoo/auto/test-artifacts


### PR DESCRIPTION
This new v13+ feature helps debugging JS tests. It makes sense to ship a default location for these things. Settings won't hurt on lower versions.

This combines with https://github.com/Tecnativa/doodba-copier-template/pull/68 to become actually useful.