### PR TITLE
Install older autoprefixer-rails dependency

### DIFF
--- a/11.0.Dockerfile
+++ b/11.0.Dockerfile
@@ -70,7 +70,8 @@ RUN ln -s /usr/bin/nodejs /usr/local/bin/node \
     && rm -Rf ~/.npm /tmp/*
 
 # Special case to get bootstrap-sass, required by Odoo for Sass assets
-RUN gem install --no-rdoc --no-ri --no-update-sources bootstrap-sass --version '<3.4' \
+RUN gem install --no-rdoc --no-ri --no-update-sources autoprefixer-rails --version '<9.8.6' \
+    && gem install --no-rdoc --no-ri --no-update-sources bootstrap-sass --version '<3.4' \
     && rm -Rf ~/.gem /var/lib/gems/*/cache/
 
 # Other facilities

--- a/8.0.Dockerfile
+++ b/8.0.Dockerfile
@@ -75,7 +75,8 @@ RUN ln -s /usr/bin/nodejs /usr/local/bin/node \
     && rm -Rf ~/.npm /tmp/*
 
 # Special case to get bootstrap-sass, required by Odoo for Sass assets
-RUN gem install --no-rdoc --no-ri --no-update-sources bootstrap-sass --version '<3.4' \
+RUN gem install --no-rdoc --no-ri --no-update-sources autoprefixer-rails --version '<9.8.6' \
+    && gem install --no-rdoc --no-ri --no-update-sources bootstrap-sass --version '<3.4' \
     && rm -Rf ~/.gem /var/lib/gems/*/cache/
 
 # Other facilities


### PR DESCRIPTION
[Last weekly build][1] failed with:

```
#8 [base 5/18] RUN gem install --no-rdoc --no-ri --no-update-sources bootst...
#8 4.129 ERROR:  Error installing bootstrap-sass:
#8 4.129 	autoprefixer-rails requires Ruby version >= 2.4.
#8 4.147 Successfully installed execjs-2.7.0
#8 ERROR: executor failed running [/bin/sh -c gem install --no-rdoc --no-ri --no-update-sources bootstrap-sass --version '<3.4'     && rm -Rf ~/.gem /var/lib/gems/*/cache/]: runc did not terminate sucessfully
```

[Second to last build][2] passed with:

```
#7 [base 4/16] RUN gem install --no-rdoc --no-ri --no-update-sources bootst...
#7 1.419 Successfully installed execjs-2.7.0
#7 1.419 Successfully installed autoprefixer-rails-9.8.5
#7 1.419 Successfully installed bootstrap-sass-3.3.7
#7 1.419 3 gems installed
#7 DONE 1.5s
```

So, it seems like latest update for `autoprefixer-rails` doesn't support our old ruby version. Thus, forcing install of older version to fix builds.

[1]: https://github.com/Tecnativa/doodba/actions/runs/191647681
[2]: https://github.com/Tecnativa/doodba/actions/runs/182679943