### PR TITLE
Fix autoaggregate in python 2 versions

### DIFF
--- a/bin/autoaggregate
+++ b/bin/autoaggregate
@@ -48,6 +48,7 @@ def aggregate(config):
                 log_level,
                 "--jobs",
                 str(cpu_count() or 1),
+                "aggregate",
             ],
             cwd=SRC_DIR,
             stderr=sys.stderr,


### PR DESCRIPTION

Recently Python 2 builds (Odoo <= v10) started failing due to https://github.com/acsone/git-aggregator/issues/47.

Here's the fix.