### PR TITLE
Update ptvsd -> debugpy

### DIFF
--- a/11.0.Dockerfile
+++ b/11.0.Dockerfile
@@ -20,8 +20,8 @@ ENV DB_FILTER=.* \
     OPENERP_SERVER=/opt/odoo/auto/odoo.conf \
     PATH="/home/odoo/.local/bin:$PATH" \
     PIP_NO_CACHE_DIR=0 \
-    PTVSD_ARGS="--host 0.0.0.0 --port 6899 --wait --multiprocess" \
-    PTVSD_ENABLE=0 \
+    DEBUGPY_ARGS="--listen 0.0.0.0:6899 --wait-for-client" \
+    DEBUGPY_ENABLE=0 \
     PUDB_RDB_HOST=0.0.0.0 \
     PUDB_RDB_PORT=6899 \
     PYTHONOPTIMIZE=1 \
@@ -82,7 +82,7 @@ RUN pip install \
         git-aggregator \
         pg_activity \
         plumbum \
-        ptvsd \
+        debugpy \
         pudb \
         watchdog \
         wdb \

--- a/11.0.Dockerfile
+++ b/11.0.Dockerfile
@@ -20,6 +20,8 @@ ENV DB_FILTER=.* \
     OPENERP_SERVER=/opt/odoo/auto/odoo.conf \
     PATH="/home/odoo/.local/bin:$PATH" \
     PIP_NO_CACHE_DIR=0 \
+    PTVSD_ARGS="--host 0.0.0.0 --port 6899 --wait --multiprocess" \
+    PTVSD_ENABLE=0 \
     DEBUGPY_ARGS="--listen 0.0.0.0:6899 --wait-for-client" \
     DEBUGPY_ENABLE=0 \
     PUDB_RDB_HOST=0.0.0.0 \
@@ -82,6 +84,7 @@ RUN pip install \
         git-aggregator \
         pg_activity \
         plumbum \
+        ptvsd \
         debugpy \
         pudb \
         watchdog \

--- a/12.0.Dockerfile
+++ b/12.0.Dockerfile
@@ -20,8 +20,8 @@ ENV DB_FILTER=.* \
     OPENERP_SERVER=/opt/odoo/auto/odoo.conf \
     PATH="/home/odoo/.local/bin:$PATH" \
     PIP_NO_CACHE_DIR=0 \
-    PTVSD_ARGS="--host 0.0.0.0 --port 6899 --wait --multiprocess" \
-    PTVSD_ENABLE=0 \
+    DEBUGPY_ARGS="--listen 0.0.0.0:6899 --wait-for-client" \
+    DEBUGPY_ENABLE=0 \
     PUDB_RDB_HOST=0.0.0.0 \
     PUDB_RDB_PORT=6899 \
     PYTHONOPTIMIZE=1 \
@@ -77,7 +77,7 @@ RUN pip install \
         git-aggregator \
         pg_activity \
         plumbum \
-        ptvsd \
+        debugpy \
         pudb \
         watchdog \
         wdb \

--- a/12.0.Dockerfile
+++ b/12.0.Dockerfile
@@ -20,6 +20,8 @@ ENV DB_FILTER=.* \
     OPENERP_SERVER=/opt/odoo/auto/odoo.conf \
     PATH="/home/odoo/.local/bin:$PATH" \
     PIP_NO_CACHE_DIR=0 \
+    PTVSD_ARGS="--host 0.0.0.0 --port 6899 --wait --multiprocess" \
+    PTVSD_ENABLE=0 \
     DEBUGPY_ARGS="--listen 0.0.0.0:6899 --wait-for-client" \
     DEBUGPY_ENABLE=0 \
     PUDB_RDB_HOST=0.0.0.0 \
@@ -77,6 +79,7 @@ RUN pip install \
         git-aggregator \
         pg_activity \
         plumbum \
+        ptvsd \
         debugpy \
         pudb \
         watchdog \

--- a/13.0.Dockerfile
+++ b/13.0.Dockerfile
@@ -20,8 +20,8 @@ ENV DB_FILTER=.* \
     OPENERP_SERVER=/opt/odoo/auto/odoo.conf \
     PATH="/home/odoo/.local/bin:$PATH" \
     PIP_NO_CACHE_DIR=0 \
-    PTVSD_ARGS="--host 0.0.0.0 --port 6899 --wait --multiprocess" \
-    PTVSD_ENABLE=0 \
+    DEBUGPY_ARGS="--listen 0.0.0.0:6899 --wait-for-client" \
+    DEBUGPY_ENABLE=0 \
     PUDB_RDB_HOST=0.0.0.0 \
     PUDB_RDB_PORT=6899 \
     PYTHONOPTIMIZE=1 \
@@ -132,7 +132,7 @@ RUN build_deps=" \
         pg_activity \
         phonenumbers \
         plumbum \
-        ptvsd \
+        debugpy \
         pudb \
         watchdog \
         wdb \

--- a/13.0.Dockerfile
+++ b/13.0.Dockerfile
@@ -20,6 +20,8 @@ ENV DB_FILTER=.* \
     OPENERP_SERVER=/opt/odoo/auto/odoo.conf \
     PATH="/home/odoo/.local/bin:$PATH" \
     PIP_NO_CACHE_DIR=0 \
+    PTVSD_ARGS="--host 0.0.0.0 --port 6899 --wait --multiprocess" \
+    PTVSD_ENABLE=0 \
     DEBUGPY_ARGS="--listen 0.0.0.0:6899 --wait-for-client" \
     DEBUGPY_ENABLE=0 \
     PUDB_RDB_HOST=0.0.0.0 \
@@ -132,6 +134,7 @@ RUN build_deps=" \
         pg_activity \
         phonenumbers \
         plumbum \
+        ptvsd \
         debugpy \
         pudb \
         watchdog \

--- a/8.0.Dockerfile
+++ b/8.0.Dockerfile
@@ -20,6 +20,8 @@ ENV DB_FILTER=.* \
     OPENERP_SERVER=/opt/odoo/auto/odoo.conf \
     PATH="/home/odoo/.local/bin:$PATH" \
     PIP_NO_CACHE_DIR=0 \
+    PTVSD_ARGS="--host 0.0.0.0 --port 6899 --wait --multiprocess" \
+    PTVSD_ENABLE=0 \
     DEBUGPY_ARGS="--listen 0.0.0.0:6899 --wait-for-client" \
     DEBUGPY_ENABLE=0 \
     PUDB_RDB_HOST=0.0.0.0 \
@@ -85,6 +87,7 @@ RUN pip install \
         click-odoo-contrib \
         git-aggregator \
         plumbum \
+        ptvsd \
         debugpy \
         pudb \
         virtualenv \

--- a/8.0.Dockerfile
+++ b/8.0.Dockerfile
@@ -20,8 +20,8 @@ ENV DB_FILTER=.* \
     OPENERP_SERVER=/opt/odoo/auto/odoo.conf \
     PATH="/home/odoo/.local/bin:$PATH" \
     PIP_NO_CACHE_DIR=0 \
-    PTVSD_ARGS="--host 0.0.0.0 --port 6899 --wait --multiprocess" \
-    PTVSD_ENABLE=0 \
+    DEBUGPY_ARGS="--listen 0.0.0.0:6899 --wait-for-client" \
+    DEBUGPY_ENABLE=0 \
     PUDB_RDB_HOST=0.0.0.0 \
     PUDB_RDB_PORT=6899 \
     PYTHONOPTIMIZE=1 \
@@ -85,7 +85,7 @@ RUN pip install \
         click-odoo-contrib \
         git-aggregator \
         plumbum \
-        ptvsd \
+        debugpy \
         pudb \
         virtualenv \
         wdb \

--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ To debug at a certain point of the code, add this Python code somewhere:
 
 ```python
 import debugpy
-debugpy.listen(6899)
+debugpy.listen(5678)
 print("Waiting for debugger attach")
 debugpy.wait_for_client()
 debugpy.breakpoint()
@@ -563,7 +563,7 @@ your project there is a `.vscode/launch.json` file with these minimal contents:
           "remoteRoot": "/opt/odoo"
         }
       ],
-      "port": 6899,
+      "port": 5678,
       "host": "localhost"
     }
   ]

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ You can start working with this straight away with our [template][].
   - [`pot`](#pot)
   - [`psql`](#psql)
   - [`inotify`](#inotify)
-  - [`ptvsd`](#ptvsd)
+  - [`debugpy`](#debugpy)
   - [`pudb`](#pudb)
   - [`git-aggregator`](#git-aggregator)
   - [`autoaggregate`](#autoaggregate)
@@ -519,7 +519,7 @@ Doodba supports this feature under;
 - [12.0](https://www.odoo.com/documentation/12.0/reference/cmdline.html#developer-features)
 - [13.0](https://www.odoo.com/documentation/13.0/reference/cmdline.html#developer-features)
 
-### [`ptvsd`](https://github.com/DonJayamanne/pythonVSCode)
+### [`debugpy`](https://github.com/microsoft/vscode-python)
 
 [VSCode][] debugger. If you use this editor with its python module, you will find it
 useful.
@@ -527,19 +527,22 @@ useful.
 To debug at a certain point of the code, add this Python code somewhere:
 
 ```python
-import ptvsd
-ptvsd.enable_attach("doodba-rocks", address=("0.0.0.0", 6899))
-print("ptvsd waiting...")
-ptvsd.wait_for_attach()
+import debugpy
+debugpy.listen(6899)
+print("Waiting for debugger attach")
+debugpy.wait_for_client()
+debugpy.breakpoint()
+print('break on this line')
 ```
 
-To start Odoo within a ptvsd environment, which will obey the breakpoints established in
-your IDE (but will work slowly), just add `-e PTVSD_ENABLE=1` to your odoo container.
+To start Odoo within a debugpy environment, which will obey the breakpoints established
+in your IDE (but will work slowly), just add `-e DEBUGPY_ENABLE=1` to your odoo
+container.
 
-If you use the official [template][], you can boot it in ptvsd mode with:
+If you use the official [template][], you can boot it in debugpy mode with:
 
 ```bash
-export DOODBA_PTVSD_ENABLE=1
+export DOODBA_DEBUGPY_ENABLE=1
 docker-compose -f devel.yaml up -d
 ```
 

--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ To debug at a certain point of the code, add this Python code somewhere:
 
 ```python
 import debugpy
-debugpy.listen(5678)
+debugpy.listen(6899)
 print("Waiting for debugger attach")
 debugpy.wait_for_client()
 debugpy.breakpoint()
@@ -563,7 +563,7 @@ your project there is a `.vscode/launch.json` file with these minimal contents:
           "remoteRoot": "/opt/odoo"
         }
       ],
-      "port": 5678,
+      "port": 6899,
       "host": "localhost"
     }
   ]

--- a/bin/direxec
+++ b/bin/direxec
@@ -4,7 +4,7 @@
 import os
 import subprocess
 import sys
-from logging import DEBUG, INFO
+from logging import DEBUG, INFO, WARNING
 
 from doodbalib import logger, which
 
@@ -45,7 +45,21 @@ if extra_command:
             except OperationalError:
                 # No DB exists, set initial language
                 extra_command += ["--load-language", os.environ["INITIAL_LANG"]]
-        if os.environ["DEBUGPY_ENABLE"] == "1":
+        if os.environ["PTVSD_ENABLE"] == "1":
+            # Warn deprecation
+            logger.log(
+                WARNING,
+                "ptvsd has beed deprecated for python debugging. \
+                Please use debugpy (see https://github.com/Tecnativa/doodba#debugpy)",
+            )
+            # See `python -m ptvsd -h` to understand this
+            extra_command[0] = os.path.realpath(which(extra_command[0]))
+            extra_command = (
+                ["python", "-m", "ptvsd"]
+                + os.environ["PTVSD_ARGS"].split()
+                + extra_command
+            )
+        elif os.environ["DEBUGPY_ENABLE"] == "1":
             # See `python -m debugpy -h` to understand this
             extra_command[0] = os.path.realpath(which(extra_command[0]))
             extra_command = (

--- a/bin/direxec
+++ b/bin/direxec
@@ -49,8 +49,8 @@ if extra_command:
             # Warn deprecation
             logger.log(
                 WARNING,
-                "ptvsd has beed deprecated for python debugging. \
-                Please use debugpy (see https://github.com/Tecnativa/doodba#debugpy)",
+                "ptvsd has beed deprecated for python debugging. "
+                "Please use debugpy (see https://github.com/Tecnativa/doodba#debugpy)",
             )
             # See `python -m ptvsd -h` to understand this
             extra_command[0] = os.path.realpath(which(extra_command[0]))

--- a/bin/direxec
+++ b/bin/direxec
@@ -45,12 +45,12 @@ if extra_command:
             except OperationalError:
                 # No DB exists, set initial language
                 extra_command += ["--load-language", os.environ["INITIAL_LANG"]]
-        if os.environ["PTVSD_ENABLE"] == "1":
-            # See `python -m ptvsd -h` to understand this
+        if os.environ["DEBUGPY_ENABLE"] == "1":
+            # See `python -m debugpy -h` to understand this
             extra_command[0] = os.path.realpath(which(extra_command[0]))
             extra_command = (
-                ["python", "-m", "ptvsd"]
-                + os.environ["PTVSD_ARGS"].split()
+                ["python", "-m", "debugpy"]
+                + os.environ["DEBUGPY_ARGS"].split()
                 + extra_command
             )
     logger.log(


### PR DESCRIPTION
Seems like `debugpy` is the recommended library for debugging Python with VSCode, so it makes sense to make this transition.

https://code.visualstudio.com/docs/python/debugging#_debugging-by-attaching-over-a-network-connection 
https://github.com/microsoft/debugpy

This updates the container, but it is still needed to update the template under copier (see https://github.com/Tecnativa/doodba-copier-template/pull/127)

TT25875