### PR TITLE
upgrade to to new github api

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,8 +17,9 @@ jobs:
       - uses: actions/setup-python@v1
       - name: Set PY
         run:
-          echo "::set-env name=PY::$(python -c 'import hashlib,
+          echo "PY=$(python -c 'import hashlib,
           sys;print(hashlib.sha256(sys.version.encode()+sys.executable.encode()).hexdigest())')"
+          >> $GITHUB_ENV
       - uses: actions/cache@v1
         with:
           path: ~/.cache/pre-commit


### PR DESCRIPTION
> The `set-env` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/