### PR TITLE
Update 14.0 Dockerfile to use Python 3.8, as in Odoo.sh and runbots

### DIFF
--- a/14.0.Dockerfile
+++ b/14.0.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-slim-buster AS base
+FROM python:3.8-slim-buster AS base
 
 EXPOSE 8069 8072
 
@@ -66,7 +66,7 @@ RUN apt-get -qq update \
 
 WORKDIR /opt/odoo
 COPY bin/* /usr/local/bin/
-COPY lib/doodbalib /usr/local/lib/python3.6/site-packages/doodbalib
+COPY lib/doodbalib /usr/local/lib/python3.8/site-packages/doodbalib
 COPY build.d common/build.d
 COPY conf.d common/conf.d
 COPY entrypoint.d common/entrypoint.d
@@ -74,7 +74,7 @@ RUN mkdir -p auto/addons auto/geoip custom/src/private \
     && ln /usr/local/bin/direxec common/entrypoint \
     && ln /usr/local/bin/direxec common/build \
     && chmod -R a+rx common/entrypoint* common/build* /usr/local/bin \
-    && chmod -R a+rX /usr/local/lib/python3.6/site-packages/doodbalib \
+    && chmod -R a+rX /usr/local/lib/python3.8/site-packages/doodbalib \
     && mv /etc/GeoIP.conf /opt/odoo/auto/geoip/GeoIP.conf \
     && ln -s /opt/odoo/auto/geoip/GeoIP.conf /etc/GeoIP.conf \
     && sed -i 's/.*DatabaseDirectory .*$/DatabaseDirectory \/opt\/odoo\/auto\/geoip\//g' /opt/odoo/auto/geoip/GeoIP.conf \
@@ -136,7 +136,7 @@ RUN build_deps=" \
         pudb \
         watchdog \
         wdb \
-    && (python3 -m compileall -q /usr/local/lib/python3.6/ || true) \
+    && (python3 -m compileall -q /usr/local/lib/python3.8/ || true) \
     && apt-get purge -yqq $build_deps \
     && apt-get autopurge -yqq \
     && rm -Rf /var/lib/apt/lists/* /tmp/*


### PR DESCRIPTION
Seems like Odoo is using Python 3.8 for Runbots and Odoo.sh in v14: https://github.com/odoo/runbot/issues/414#issuecomment-710311902

TT26297