### PR TITLE
Add pydevd-odoo plugin

### DIFF
--- a/11.0.Dockerfile
+++ b/11.0.Dockerfile
@@ -86,6 +86,7 @@ RUN pip install \
         plumbum \
         ptvsd \
         debugpy \
+        pydevd-odoo \
         pudb \
         watchdog \
         wdb \

--- a/12.0.Dockerfile
+++ b/12.0.Dockerfile
@@ -81,6 +81,7 @@ RUN pip install \
         plumbum \
         ptvsd \
         debugpy \
+        pydevd-odoo \
         pudb \
         watchdog \
         wdb \

--- a/13.0.Dockerfile
+++ b/13.0.Dockerfile
@@ -136,6 +136,7 @@ RUN build_deps=" \
         plumbum \
         ptvsd \
         debugpy \
+        pydevd-odoo \
         pudb \
         watchdog \
         wdb \

--- a/14.0.Dockerfile
+++ b/14.0.Dockerfile
@@ -127,6 +127,7 @@ RUN build_deps=" \
         astor \
         click-odoo-contrib \
         debugpy \
+        pydevd-odoo \
         geoip2 \
         git-aggregator \
         inotify \

--- a/8.0.Dockerfile
+++ b/8.0.Dockerfile
@@ -89,6 +89,7 @@ RUN pip install \
         plumbum \
         ptvsd \
         debugpy \
+        pydevd-odoo \
         pudb \
         virtualenv \
         wdb \


### PR DESCRIPTION
This plugin enables recordset debug collection in Doodba and
is compatible with all IDE's supporting pydevd including VSCode
and pycharm.