### PR TITLE
Remove pydevd-odoo for Odoo <= v10

### DIFF
--- a/8.0.Dockerfile
+++ b/8.0.Dockerfile
@@ -89,7 +89,6 @@ RUN pip install \
         plumbum \
         ptvsd \
         debugpy \
-        pydevd-odoo \
         pudb \
         virtualenv \
         wdb \


### PR DESCRIPTION
Partially reverts https://github.com/Tecnativa/doodba/commit/4fa82ccfb99ddb6f06e745ecfc3d6dccd2add861
Pydevd-odoo introduces Syntax Error for python < 3 https://github.com/trinhanhngoc/pydevd-odoo/blob/master/pydevd_plugins/extensions/pydevd_plugin_odoo.py#L37
This eliminates pydevd-odoo functionality but keeps debugging working

TT26189