### PR TITLE
Always regenerate odoo.conf file

### DIFF
--- a/entrypoint.d/50-config-generate
+++ b/entrypoint.d/50-config-generate
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-if [ -f  "${OPENERP_SERVER}" ]; then
-    log INFO File $OPENERP_SERVER exists, skipping config generation
-    exit 0
-fi
+log INFO Generating $OPENERP_SERVER file. Overriding any existing...
 
 config-generate


### PR DESCRIPTION
Instead of only regenerating the `/opt/odoo/auto/odoo.conf` file when none exists, always regenerate it.

TT26597