### PR TITLE
FIX: Temporarily remove pydevd-odoo

### DIFF
--- a/14.0.Dockerfile
+++ b/14.0.Dockerfile
@@ -99,6 +99,8 @@ ARG ODOO_VERSION=14.0
 ENV ODOO_VERSION="$ODOO_VERSION"
 
 # Install Odoo hard & soft dependencies, and Doodba utilities
+# TODO: Add back pydevd-odoo once
+# https://github.com/trinhanhngoc/pydevd-odoo/issues/3 is fixed
 RUN build_deps=" \
         build-essential \
         libfreetype6-dev \
@@ -127,7 +129,6 @@ RUN build_deps=" \
         astor \
         click-odoo-contrib \
         debugpy \
-        pydevd-odoo \
         geoip2 \
         git-aggregator \
         inotify \


### PR DESCRIPTION
Pydev-odoo introduces error in Python 3.8 (used in v14): https://github.com/trinhanhngoc/pydevd-odoo/issues/3

Removing until issue is fixed

cc @Tecnativa @Yajo 