### PR TITLE
Migrate from GitHub Packages Docker registry to GitHub Container Registry

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,11 +75,11 @@ jobs:
           REGISTRY_PASSWORD: ${{ secrets.dockerhub_password }}
           REGISTRY_USERNAME: ${{ secrets.dockerhub_username }}
         run: ./hooks/push
-      - name: push to github registry
+      - name: push to github container registry
         if: github.repository == 'Tecnativa/doodba' && github.ref == 'refs/heads/master'
         env:
           DOCKER_REPO_SUFFIX: /doodba
-          REGISTRY_HOST: docker.pkg.github.com
-          REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-          REGISTRY_USERNAME: ${{ github.actor }}
+          REGISTRY_HOST: ghcr.io
+          REGISTRY_PASSWORD: ${{ secrets.GHCR_PASSWORD }}
+          REGISTRY_USERNAME: ${{ secrets.GHCR_USERNAME }}
         run: ./hooks/push

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,6 +80,6 @@ jobs:
         env:
           DOCKER_REPO_SUFFIX: /doodba
           REGISTRY_HOST: ghcr.io
-          REGISTRY_PASSWORD: ${{ secrets.GHCR_PASSWORD }}
-          REGISTRY_USERNAME: ${{ secrets.GHCR_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.BOT_TOKEN }}
+          REGISTRY_USERNAME: ${{ secrets.BOT_LOGIN }}
         run: ./hooks/push


### PR DESCRIPTION
As explained in several warnings like https://docs.github.com/en/free-pro-team@latest/packages/using-github-packages-with-your-projects-ecosystem/configuring-docker-for-use-with-github-packages#about-docker-and-github-packages, GitHub Packages Docker registry will soon be deprecated in favour of GHCR. This is a good chance to migrate to the new registry, and also improve our CI flow in https://github.com/Tecnativa/doodba-copier-template with this images.

ping @Yajo 
I think you will need to add the respective secrets in the project.

@Tecnativa TT26590