### PR TITLE
Fix push action to run on poetry env

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,11 +78,11 @@ jobs:
           REGISTRY_HOST: docker.io
           REGISTRY_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
           REGISTRY_USERNAME: ${{ secrets.DOCKERHUB_LOGIN }}
-        run: ./hooks/push
+        run: poetry run ./hooks/push
       - name: push to github container registry
         if: github.repository == 'Tecnativa/doodba' && github.ref == 'refs/heads/master'
         env:
           REGISTRY_HOST: ghcr.io
           REGISTRY_PASSWORD: ${{ secrets.BOT_TOKEN }}
           REGISTRY_USERNAME: ${{ secrets.BOT_LOGIN }}
-        run: ./hooks/push
+        run: poetry run ./hooks/push


### PR DESCRIPTION
As done before with build action, now use the `poetry` environment instead of installing everything with `pip`

Fixes https://github.com/Tecnativa/doodba/runs/1576018407 and is a continuation of https://github.com/Tecnativa/doodba/pull/361/commits/b6615c1d88a060d154ed32872945f07cad26b447