### PR TITLE
image: enable defining postgres client version on build

### DIFF
--- a/11.0.Dockerfile
+++ b/11.0.Dockerfile
@@ -55,7 +55,7 @@ RUN apt-get -qq update \
     && curl https://bootstrap.pypa.io/get-pip.py | python3 /dev/stdin \
     && curl -sL https://deb.nodesource.com/setup_6.x | bash - \
     && apt-get update \
-    && apt-get install -yqq --no-install-recommends nodejs postgresql-client \
+    && apt-get install -yqq --no-install-recommends nodejs \
     && curl -SLo wkhtmltox.deb https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/${WKHTMLTOPDF_VERSION}/wkhtmltox_${WKHTMLTOPDF_VERSION}-1.stretch_amd64.deb \
     && echo "${WKHTMLTOPDF_CHECKSUM}  wkhtmltox.deb" | sha256sum -c - \
     && apt-get install -yqq --no-install-recommends ./wkhtmltox.deb \
@@ -221,6 +221,7 @@ ONBUILD RUN mkdir -p /opt/odoo/custom/ssh \
             && ln -s /opt/odoo/custom/ssh ~root/.ssh \
             && chmod -R u=rwX,go= /opt/odoo/custom/ssh \
             && sync
+ONBUILD ARG DB_VERSION=latest
 ONBUILD RUN /opt/odoo/common/build && sync
 ONBUILD VOLUME ["/var/lib/odoo"]
 ONBUILD USER odoo

--- a/12.0.Dockerfile
+++ b/12.0.Dockerfile
@@ -55,7 +55,7 @@ RUN apt-get -qq update \
     && curl https://bootstrap.pypa.io/get-pip.py | python3 /dev/stdin \
     && curl -sL https://deb.nodesource.com/setup_8.x | bash - \
     && apt-get update \
-    && apt-get install -yqq --no-install-recommends nodejs postgresql-client \
+    && apt-get install -yqq --no-install-recommends nodejs \
     && curl -SLo wkhtmltox.deb https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/${WKHTMLTOPDF_VERSION}/wkhtmltox_${WKHTMLTOPDF_VERSION}-1.stretch_amd64.deb \
     && echo "${WKHTMLTOPDF_CHECKSUM}  wkhtmltox.deb" | sha256sum -c - \
     && apt-get install -yqq --no-install-recommends ./wkhtmltox.deb \
@@ -216,6 +216,7 @@ ONBUILD RUN mkdir -p /opt/odoo/custom/ssh \
             && ln -s /opt/odoo/custom/ssh ~root/.ssh \
             && chmod -R u=rwX,go= /opt/odoo/custom/ssh \
             && sync
+ONBUILD ARG DB_VERSION=latest
 ONBUILD RUN /opt/odoo/common/build && sync
 ONBUILD VOLUME ["/var/lib/odoo"]
 ONBUILD USER odoo

--- a/13.0.Dockerfile
+++ b/13.0.Dockerfile
@@ -59,7 +59,7 @@ RUN apt-get -qq update \
     && echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main' >> /etc/apt/sources.list.d/postgresql.list \
     && curl -SL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
     && apt-get update \
-    && apt-get install -yqq --no-install-recommends postgresql-client \
+    && apt-get install -yqq --no-install-recommends \
     && curl --silent -L --output geoipupdate_${GEOIP_UPDATER_VERSION}_linux_amd64.deb https://github.com/maxmind/geoipupdate/releases/download/v${GEOIP_UPDATER_VERSION}/geoipupdate_${GEOIP_UPDATER_VERSION}_linux_amd64.deb \
     && dpkg -i geoipupdate_${GEOIP_UPDATER_VERSION}_linux_amd64.deb \
     && rm geoipupdate_${GEOIP_UPDATER_VERSION}_linux_amd64.deb \
@@ -229,6 +229,7 @@ ONBUILD RUN mkdir -p /opt/odoo/custom/ssh \
             && ln -s /opt/odoo/custom/ssh ~root/.ssh \
             && chmod -R u=rwX,go= /opt/odoo/custom/ssh \
             && sync
+ONBUILD ARG DB_VERSION=latest
 ONBUILD RUN /opt/odoo/common/build && sync
 ONBUILD VOLUME ["/var/lib/odoo"]
 ONBUILD USER odoo

--- a/14.0.Dockerfile
+++ b/14.0.Dockerfile
@@ -56,7 +56,6 @@ RUN apt-get -qq update \
     && echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main' >> /etc/apt/sources.list.d/postgresql.list \
     && curl -SL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
     && apt-get update \
-    && apt-get install -yqq --no-install-recommends postgresql-client \
     && curl --silent -L --output geoipupdate_${GEOIP_UPDATER_VERSION}_linux_amd64.deb https://github.com/maxmind/geoipupdate/releases/download/v${GEOIP_UPDATER_VERSION}/geoipupdate_${GEOIP_UPDATER_VERSION}_linux_amd64.deb \
     && dpkg -i geoipupdate_${GEOIP_UPDATER_VERSION}_linux_amd64.deb \
     && rm geoipupdate_${GEOIP_UPDATER_VERSION}_linux_amd64.deb \
@@ -225,6 +224,7 @@ ONBUILD RUN mkdir -p /opt/odoo/custom/ssh \
             && ln -s /opt/odoo/custom/ssh ~root/.ssh \
             && chmod -R u=rwX,go= /opt/odoo/custom/ssh \
             && sync
+ONBUILD ARG DB_VERSION=latest
 ONBUILD RUN /opt/odoo/common/build && sync
 ONBUILD VOLUME ["/var/lib/odoo"]
 ONBUILD USER odoo

--- a/8.0.Dockerfile
+++ b/8.0.Dockerfile
@@ -64,12 +64,9 @@ RUN sed -Ei 's@(^deb http://deb.debian.org/debian jessie-updates main$)@#\1@' /e
     && rm geoipupdate_${GEOIP_UPDATER_VERSION}_linux_amd64.deb \
     && rm -Rf /var/lib/apt/lists/*
 
-# Special case to get latest PostgreSQL client
+# Special case to get latest PostgreSQL client in 250-postgres-client
 RUN echo 'deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main' >> /etc/apt/sources.list.d/postgresql.list \
     && curl -SL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends postgresql-client \
-    && rm -Rf /var/lib/apt/lists/* /tmp/*
 
 # Special case to get latest Less and PhantomJS
 RUN ln -s /usr/bin/nodejs /usr/local/bin/node \
@@ -218,6 +215,7 @@ ONBUILD RUN mkdir -p /opt/odoo/custom/ssh \
             && ln -s /opt/odoo/custom/ssh ~root/.ssh \
             && chmod -R u=rwX,go= /opt/odoo/custom/ssh \
             && sync
+ONBUILD ARG DB_VERSION=latest
 ONBUILD RUN /opt/odoo/common/build && sync
 ONBUILD VOLUME ["/var/lib/odoo"]
 ONBUILD USER odoo

--- a/bin/direxec
+++ b/bin/direxec
@@ -8,8 +8,6 @@ from logging import DEBUG, INFO, WARNING
 
 from doodbalib import logger, which
 
-from psycopg2 import OperationalError, connect
-
 # Call this file linked from another file called `build` or `entrypoint`
 mode = os.path.basename(__file__)
 
@@ -39,6 +37,8 @@ if extra_command:
     # Set the DB creation language, if needed
     if extra_command[0] in {"odoo", "/usr/local/bin/odoo"}:
         if os.environ.get("INITIAL_LANG"):
+            from psycopg2 import OperationalError, connect
+
             try:
                 connection = connect(dbname=os.environ.get("PGDATABASE"))
                 connection.close()

--- a/build.d/250-postgres-client
+++ b/build.d/250-postgres-client
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+apt-get update
+if [[ "$DB_VERSION" != "latest" ]] ; then
+    apt-get install -yqq postgresql-client-$DB_VERSION
+else
+    apt-get install -yqq postgresql-client
+fi

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -532,6 +532,38 @@ class ScaffoldingCase(unittest.TestCase):
                 ),
             )
 
+    def test_postgres_client_version(self):
+        postgres_client_version_dir = join(SCAFFOLDINGS_DIR, "postgres_client_version")
+        for sub_env in matrix():
+            self.compose_test(
+                postgres_client_version_dir,
+                sub_env,
+                ("psql", "--version"),
+                # verify that psql --version is as expected
+                (
+                    "bash",
+                    "-c",
+                    '[[ "$(psql --version)" == "psql (PostgreSQL) %s."* ]]'
+                    % sub_env["DB_VERSION"],
+                ),
+                ("pg_dump", "--version"),
+                # verify that pg_dump --version is as expected
+                (
+                    "bash",
+                    "-c",
+                    '[[ "$(pg_dump --version)" == "pg_dump (PostgreSQL) %s."* ]]'
+                    % sub_env["DB_VERSION"],
+                ),
+                ("pg_restore", "--version"),
+                # verify that pg_restore --version is as expected
+                (
+                    "bash",
+                    "-c",
+                    '[[ "$(pg_restore --version)" == "pg_restore (PostgreSQL) %s."* ]]'
+                    % sub_env["DB_VERSION"],
+                ),
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/scaffoldings/postgres_client_version/Dockerfile
+++ b/tests/scaffoldings/postgres_client_version/Dockerfile
@@ -1,0 +1,2 @@
+ARG ODOO_VERSION
+FROM tecnativa/doodba:${ODOO_VERSION}-onbuild

--- a/tests/scaffoldings/postgres_client_version/docker-compose.yaml
+++ b/tests/scaffoldings/postgres_client_version/docker-compose.yaml
@@ -1,0 +1,31 @@
+version: "2.1"
+services:
+  odoo:
+    build:
+      context: ./
+      args:
+        COMPILE: "false"
+        ODOO_VERSION: $ODOO_MINOR
+        PIP_INSTALL_ODOO: "false"
+        WITHOUT_DEMO: "false"
+        DB_VERSION: ${DB_VERSION}
+    tty: true
+    depends_on:
+      - db
+    environment:
+      PYTHONOPTIMIZE: ""
+      UNACCENT: "false"
+    volumes:
+      - filestore:/var/lib/odoo:z
+
+  db:
+    image: postgres:${DB_VERSION}-alpine
+    environment:
+      POSTGRES_USER: odoo
+      POSTGRES_PASSWORD: odoopassword
+    volumes:
+      - db:/var/lib/postgresql/data:z
+
+volumes:
+  db:
+  filestore:


### PR DESCRIPTION
When using pg_dump in the odoo container we had the problem that we couldn't restore the dumps on our main postgres server because they where using a different pg_dump version than the pg_restore outside of the container.

With this change the version of pg_dump, psql and pg_restore inside of the odoo container can be set by adding the build parameter `DB_VERSION: ${DB_VERSION}` to use the DB_VERSION from .env or `DB_VERSION: 10` to specify a specific version for the odoo containers postgres-client package.

Unfortunately just specifying postgres-client-10 in dependencies/apt.txt did install psql version 10 but did not set as the default psql in the odoo user's path (that was still version 13)