### PR TITLE
Add option to have multiple addons versions defined in different environments

### DIFF
--- a/lib/doodbalib/__init__.py
+++ b/lib/doodbalib/__init__.py
@@ -159,11 +159,12 @@ def addons_config(filtered=True, strict=False):
             continue
         repos.discard(CORE)
         # Other addons fall in between
-        if len(repos) != 1:
+        if filtered and len(repos) != 1:
             raise AddonsConfigError(
                 u"Addon {} defined in several repos {}".format(addon, repos)
             )
-        yield addon, repos.pop()
+        for repo in repos:
+            yield addon, repo
 
 
 try:

--- a/tests/scaffoldings/addons_env_double/Dockerfile
+++ b/tests/scaffoldings/addons_env_double/Dockerfile
@@ -1,0 +1,2 @@
+ARG ODOO_VERSION
+FROM tecnativa/doodba:${ODOO_VERSION}-onbuild

--- a/tests/scaffoldings/addons_env_double/custom/src/addons.yaml
+++ b/tests/scaffoldings/addons_env_double/custom/src/addons.yaml
@@ -1,0 +1,12 @@
+---
+ONLY:
+  DOODBA_ENVIRONMENT:
+    - test
+rma-old: # rma should have version 12.0.1.6.1
+  - rma
+---
+ONLY:
+  DOODBA_ENVIRONMENT:
+    - prod
+rma-new: # rma should have version 12.0.2.0.0
+  - rma

--- a/tests/scaffoldings/addons_env_double/custom/src/repos.yaml
+++ b/tests/scaffoldings/addons_env_double/custom/src/repos.yaml
@@ -1,0 +1,25 @@
+# Odoo is always required
+./odoo:
+  defaults:
+    # Shallow repositores are faster & thinner
+    depth: $DEPTH_DEFAULT
+  remotes:
+    ocb: https://github.com/OCA/OCB.git
+    odoo: https://github.com/odoo/odoo.git
+  target: ocb $ODOO_VERSION
+  merges:
+    - ocb $ODOO_VERSION
+
+rma-old:
+  remotes:
+    origin: https://github.com/OCA/rma.git
+  target: origin _merged_branch
+  merges:
+    - origin 242b7e21a174e48f713459f836794560e68290de # rma v12.0.1.6.1
+
+rma-new:
+  remotes:
+    origin: https://github.com/OCA/rma.git
+  target: origin _merged_branch
+  merges:
+    - origin 96d2081987292ae02efda9826cbe5ba1ad84d6c3 # rma v12.0.2.0.0

--- a/tests/scaffoldings/addons_env_double/docker-compose.yaml
+++ b/tests/scaffoldings/addons_env_double/docker-compose.yaml
@@ -1,0 +1,30 @@
+version: "2.1"
+services:
+  odoo:
+    build:
+      context: ./
+      args:
+        COMPILE: "false"
+        ODOO_VERSION: $ODOO_MINOR
+        WITHOUT_DEMO: "false"
+    tty: true
+    depends_on:
+      - db
+    environment:
+      DOODBA_ENVIRONMENT: "$DOODBA_ENVIRONMENT"
+      PYTHONOPTIMIZE: ""
+      UNACCENT: "false"
+    volumes:
+      - filestore:/var/lib/odoo:z
+
+  db:
+    image: postgres:${DB_VERSION}-alpine
+    environment:
+      POSTGRES_USER: odoo
+      POSTGRES_PASSWORD: odoopassword
+    volumes:
+      - db:/var/lib/postgresql/data:z
+
+volumes:
+  db:
+  filestore:


### PR DESCRIPTION
Checking for duplicates in `doodbalib` was impeding having the same addon defined more than once in `addons.yaml`, even if it was for different environments.
This moves that check to the entrypoint, to be executed only when symlinking the addons.
Also add tests for that situation

@Tecnativa
TT27711