### PR TITLE
Fix builds: pip bootstrap

### DIFF
--- a/11.0.Dockerfile
+++ b/11.0.Dockerfile
@@ -52,7 +52,7 @@ RUN apt-get -qq update \
         zlibc \
     && echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main' >> /etc/apt/sources.list.d/postgresql.list \
     && curl -SL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
-    && curl https://bootstrap.pypa.io/get-pip.py | python3 /dev/stdin \
+    && curl https://bootstrap.pypa.io/3.5/get-pip.py | python3 /dev/stdin \
     && curl -sL https://deb.nodesource.com/setup_6.x | bash - \
     && apt-get update \
     && apt-get install -yqq --no-install-recommends nodejs \

--- a/12.0.Dockerfile
+++ b/12.0.Dockerfile
@@ -52,7 +52,7 @@ RUN apt-get -qq update \
         zlibc \
     && echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main' >> /etc/apt/sources.list.d/postgresql.list \
     && curl -SL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
-    && curl https://bootstrap.pypa.io/get-pip.py | python3 /dev/stdin \
+    && curl https://bootstrap.pypa.io/3.5/get-pip.py | python3 /dev/stdin \
     && curl -sL https://deb.nodesource.com/setup_8.x | bash - \
     && apt-get update \
     && apt-get install -yqq --no-install-recommends nodejs \

--- a/8.0.Dockerfile
+++ b/8.0.Dockerfile
@@ -48,7 +48,7 @@ RUN sed -Ei 's@(^deb http://deb.debian.org/debian jessie-updates main$)@#\1@' /e
         locales-all zlibc \
         bzip2 ca-certificates curl gettext git nano \
         openssh-client telnet xz-utils \
-    && curl https://bootstrap.pypa.io/get-pip.py | python /dev/stdin \
+    && curl https://bootstrap.pypa.io/2.7/get-pip.py | python /dev/stdin \
     && curl -sL https://deb.nodesource.com/setup_6.x | bash - \
     && apt-get install -yqq nodejs \
     && curl -SLo fonts-liberation2.deb http://ftp.debian.org/debian/pool/main/f/fonts-liberation2/fonts-liberation2_2.00.1-3_all.deb \


### PR DESCRIPTION
https://bootstrap.pypa.io/ started using python >3.5 syntax for the `get-pip.py` script.
It is, then, necessary to fetch the correct version for each image.

Fixes latest build errors: https://github.com/Tecnativa/doodba/runs/1799238330?check_suite_focus=true#step:7:1000
```bash
#5 49.44 Traceback (most recent call last):
#5 49.44   File "/dev/stdin", line 24244, in <module>
#5 49.44   File "/dev/stdin", line 199, in main
#5 49.44   File "/dev/stdin", line 82, in bootstrap
#5 49.44   File "<frozen importlib._bootstrap>", line 968, in _find_and_load
#5 49.44   File "<frozen importlib._bootstrap>", line 953, in _find_and_load_unlocked
#5 49.44   File "<frozen importlib._bootstrap>", line 896, in _find_spec
#5 49.44   File "<frozen importlib._bootstrap_external>", line 1171, in find_spec
#5 49.44   File "<frozen importlib._bootstrap_external>", line 1147, in _get_spec
#5 49.44   File "<frozen importlib._bootstrap_external>", line 1128, in _legacy_get_spec
#5 49.44   File "<frozen importlib._bootstrap>", line 444, in spec_from_loader
#5 49.44   File "<frozen importlib._bootstrap_external>", line 565, in spec_from_file_location
#5 49.44   File "/tmp/tmpiq_vcyc6/pip.zip/pip/_internal/cli/main.py", line 60
#5 49.44     sys.stderr.write(f"ERROR: {exc}")
#5 49.44                                    ^
#5 49.44 SyntaxError: invalid syntax
```