### PR TITLE
[FIX] dependencies: update pip install url and replace yanked aloha_world gem

### DIFF
--- a/11.0.Dockerfile
+++ b/11.0.Dockerfile
@@ -52,7 +52,7 @@ RUN apt-get -qq update \
         zlibc \
     && echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main' >> /etc/apt/sources.list.d/postgresql.list \
     && curl -SL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
-    && curl https://bootstrap.pypa.io/3.5/get-pip.py | python3 /dev/stdin \
+    && curl https://bootstrap.pypa.io/pip/3.5/get-pip.py | python3 /dev/stdin \
     && curl -sL https://deb.nodesource.com/setup_6.x | bash - \
     && apt-get update \
     && apt-get install -yqq --no-install-recommends nodejs \

--- a/12.0.Dockerfile
+++ b/12.0.Dockerfile
@@ -52,7 +52,7 @@ RUN apt-get -qq update \
         zlibc \
     && echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main' >> /etc/apt/sources.list.d/postgresql.list \
     && curl -SL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
-    && curl https://bootstrap.pypa.io/3.5/get-pip.py | python3 /dev/stdin \
+    && curl https://bootstrap.pypa.io/pip/3.5/get-pip.py | python3 /dev/stdin \
     && curl -sL https://deb.nodesource.com/setup_8.x | bash - \
     && apt-get update \
     && apt-get install -yqq --no-install-recommends nodejs \

--- a/8.0.Dockerfile
+++ b/8.0.Dockerfile
@@ -48,7 +48,7 @@ RUN sed -Ei 's@(^deb http://deb.debian.org/debian jessie-updates main$)@#\1@' /e
         locales-all zlibc \
         bzip2 ca-certificates curl gettext git nano \
         openssh-client telnet xz-utils \
-    && curl https://bootstrap.pypa.io/2.7/get-pip.py | python /dev/stdin \
+    && curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python /dev/stdin \
     && curl -sL https://deb.nodesource.com/setup_6.x | bash - \
     && apt-get install -yqq nodejs \
     && curl -SLo fonts-liberation2.deb http://ftp.debian.org/debian/pool/main/f/fonts-liberation2/fonts-liberation2_2.00.1-3_all.deb \

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -374,7 +374,12 @@ class ScaffoldingCase(unittest.TestCase):
                 ("busybox", "whoami"),
                 ("bash", "-xc", "echo $NODE_PATH"),
                 ("node", "-e", "require('test-npm-install')"),
-                ("aloha_world",),
+                ("hello-world",),
+                (
+                    "bash",
+                    "-c",
+                    'test "$(hello-world)" == "this is executable hello-world"',
+                ),
                 ("python", "-xc", "import Crypto; print(Crypto.__version__)"),
                 ("sh", "-xc", "rst2html.py --version | grep 'Docutils 0.14'"),
                 # ``requirements.txt`` from addon repos were processed
@@ -439,7 +444,7 @@ class ScaffoldingCase(unittest.TestCase):
                 ("sh", "-xc", "rst2html.py --version | grep 'Docutils 0.14'"),
                 # 270-gem.txt
                 ("test", "-f", "custom/dependencies/270-gem.txt"),
-                ("aloha_world",),
+                ("hello-world",),
             )
 
     def test_modified_uids(self):

--- a/tests/scaffoldings/dependencies/custom/dependencies/270-gem.txt
+++ b/tests/scaffoldings/dependencies/custom/dependencies/270-gem.txt
@@ -1,2 +1,2 @@
 # This line should be ignored
-aloha_world
+hello-world

--- a/tests/scaffoldings/dotd/custom/build.d/201-assert-dependencies
+++ b/tests/scaffoldings/dotd/custom/build.d/201-assert-dependencies
@@ -2,6 +2,6 @@
 # Dependencies are processed at step 200
 set -ex
 which busybox
-aloha_world
+hello-world
 node -e "require('test-npm-install')"
 python -c "import numpy, Crypto"

--- a/tests/scaffoldings/dotd/custom/dependencies/gem.txt
+++ b/tests/scaffoldings/dotd/custom/dependencies/gem.txt
@@ -1,2 +1,2 @@
 # This line should be ignored
-aloha_world
+hello-world


### PR DESCRIPTION
During our nightly build the builds for 11.0 and 12.0 failed with the following message:
```
Hi there!
The URL you are using to fetch this script has changed, and this one will no
longer work. Please use get-pip.py from the following URL instead:
    https://bootstrap.pypa.io/pip/3.5/get-pip.py
Sorry if this change causes any inconvenience for you!
We don't have a good mechanism to make more gradual changes here, and this
renaming is a part of an effort to make it easier to us to update these
scripts, when there's a pip release. It's also essential for improving how we
handle the `get-pip.py` scripts, when pip drops support for a Python minor
version.
There are no more renames/URL changes planned, and we don't expect that a need
would arise to do this again in the near future.
Thanks for understanding!
- Pradyun, on behalf of the volunteers who maintain pip.
```