### PR TITLE
Install pg_activity from https://github.com/dalibo/pg_activity/pull/198

### DIFF
--- a/14.0.Dockerfile
+++ b/14.0.Dockerfile
@@ -131,7 +131,7 @@ RUN build_deps=" \
         geoip2 \
         git-aggregator \
         inotify \
-        pg_activity \
+        https://github.com/dalibo/pg_activity/archive/entry-points.zip \
         phonenumbers \
         plumbum \
         pudb \


### PR DESCRIPTION
Fixes installation errors with incorrect shebang in executable.

Apply https://github.com/dalibo/pg_activity/issues/197#issuecomment-800048397 to test if the installation and tests succeed.