### PR TITLE
Fix pylint-odoo and click-odoo installation

### DIFF
--- a/11.0.Dockerfile
+++ b/11.0.Dockerfile
@@ -114,11 +114,13 @@ RUN mkdir -p auto/addons auto/geoip custom/src/private \
 COPY qa /qa
 RUN python -m venv --system-site-packages /qa/venv \
     && . /qa/venv/bin/activate \
+    # HACK: Upgrade pip: higher version needed to install pyproject.toml based packages
+    && pip install -U pip \
     && pip install --no-cache-dir \
         click \
         coverage \
         flake8 \
-        pylint-odoo \
+        git+https://github.com/OCA/pylint-odoo.git@refs/pull/329/head \
         six \
     && npm install --loglevel error --prefix /qa 'eslint@<6' \
     && deactivate \

--- a/11.0.Dockerfile
+++ b/11.0.Dockerfile
@@ -80,7 +80,8 @@ RUN gem install --no-rdoc --no-ri --no-update-sources autoprefixer-rails --versi
 WORKDIR /opt/odoo
 RUN pip install \
         astor \
-        click-odoo-contrib \
+        # Install fix from https://github.com/acsone/click-odoo-contrib/pull/93
+        git+https://github.com/Tecnativa/click-odoo-contrib.git@fix-active-modules-hashing \
         git-aggregator \
         "pg_activity<=2.0.3" \
         plumbum \

--- a/12.0.Dockerfile
+++ b/12.0.Dockerfile
@@ -107,11 +107,13 @@ RUN mkdir -p auto/addons auto/geoip custom/src/private \
 COPY qa /qa
 RUN python -m venv --system-site-packages /qa/venv \
     && . /qa/venv/bin/activate \
+    # HACK: Upgrade pip: higher version needed to install pyproject.toml based packages
+    && pip install -U pip \
     && pip install --no-cache-dir \
         click \
         coverage \
         flake8 \
-        pylint-odoo \
+        git+https://github.com/OCA/pylint-odoo.git@refs/pull/329/head \
         six \
     && npm install --loglevel error --prefix /qa 'eslint@<7' \
     && deactivate \

--- a/12.0.Dockerfile
+++ b/12.0.Dockerfile
@@ -75,7 +75,8 @@ RUN ln -s /usr/bin/nodejs /usr/local/bin/node \
 WORKDIR /opt/odoo
 RUN pip install \
         astor \
-        click-odoo-contrib \
+        # Install fix from https://github.com/acsone/click-odoo-contrib/pull/93
+        git+https://github.com/Tecnativa/click-odoo-contrib.git@fix-active-modules-hashing \
         git-aggregator \
         "pg_activity<=2.0.3" \
         plumbum \

--- a/13.0.Dockerfile
+++ b/13.0.Dockerfile
@@ -130,7 +130,8 @@ RUN build_deps=" \
         'websocket-client~=0.56' \
         astor \
         git-aggregator \
-        click-odoo-contrib \
+        # Install fix from https://github.com/acsone/click-odoo-contrib/pull/93
+        git+https://github.com/Tecnativa/click-odoo-contrib.git@fix-active-modules-hashing \
         "pg_activity<=2.0.3" \
         phonenumbers \
         plumbum \

--- a/14.0.Dockerfile
+++ b/14.0.Dockerfile
@@ -126,7 +126,8 @@ RUN build_deps=" \
         -r https://raw.githubusercontent.com/$ODOO_SOURCE/$ODOO_VERSION/requirements.txt \
         'websocket-client~=0.56' \
         astor \
-        click-odoo-contrib \
+        # Install fix from https://github.com/acsone/click-odoo-contrib/pull/93
+        git+https://github.com/Tecnativa/click-odoo-contrib.git@fix-active-modules-hashing \
         debugpy \
         geoip2 \
         git-aggregator \


### PR DESCRIPTION
~~It is required for the package setup https://github.com/OCA/pylint-odoo/blob/master/setup.py#L5
But not specified in the requirements, and pip has no control on its insallation. It is done with easy_install, which may cause problems.
See https://pip.pypa.io/en/latest/cli/pip_install/#controlling-setup-requires~~

Install version from OCA/pylint-odoo#329 with a more modern packaging method, avoiding errors with setuptools