### PR TITLE
Prepare v15

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,13 +35,14 @@ jobs:
         # Test modern Odoo versions with latest Postgres version
         pg_version: ["12"]
         odoo_version:
+          - "15.0"
           - "14.0"
           - "13.0"
           - "12.0"
           - "11.0"
     env:
       # Indicates what's the equivalent to tecnativa/doodba:latest image
-      LATEST_RELEASE: "14.0"
+      LATEST_RELEASE: "15.0"
       # Variables found by default in Docker Hub builder
       DOCKER_REPO: tecnativa/doodba
       DOCKER_TAG: ${{ matrix.odoo_version }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-.vscode
 **.pyc

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,6 @@
 
   "[dockerfile]": {
     "editor.formatOnSave": false
-  }
+  },
+  "python.analysis.extraPaths": ["./lib", "./tests"]
 }

--- a/15.0.Dockerfile
+++ b/15.0.Dockerfile
@@ -1,0 +1,233 @@
+FROM python:3.9-slim-buster AS base
+
+EXPOSE 8069 8072
+
+ARG GEOIP_UPDATER_VERSION=4.3.0
+ARG WKHTMLTOPDF_VERSION=0.12.5
+ARG WKHTMLTOPDF_CHECKSUM='1140b0ab02aa6e17346af2f14ed0de807376de475ba90e1db3975f112fbd20bb'
+ENV DB_FILTER=.* \
+    DEPTH_DEFAULT=1 \
+    DEPTH_MERGE=100 \
+    EMAIL=https://hub.docker.com/r/tecnativa/odoo \
+    GEOIP_ACCOUNT_ID="" \
+    GEOIP_LICENSE_KEY="" \
+    GIT_AUTHOR_NAME=docker-odoo \
+    INITIAL_LANG="" \
+    LC_ALL=C.UTF-8 \
+    LIST_DB=false \
+    NODE_PATH=/usr/local/lib/node_modules:/usr/lib/node_modules \
+    OPENERP_SERVER=/opt/odoo/auto/odoo.conf \
+    PATH="/home/odoo/.local/bin:$PATH" \
+    PIP_NO_CACHE_DIR=0 \
+    DEBUGPY_ARGS="--listen 0.0.0.0:6899 --wait-for-client" \
+    DEBUGPY_ENABLE=0 \
+    PUDB_RDB_HOST=0.0.0.0 \
+    PUDB_RDB_PORT=6899 \
+    PYTHONOPTIMIZE=1 \
+    UNACCENT=true \
+    WAIT_DB=true \
+    WDB_NO_BROWSER_AUTO_OPEN=True \
+    WDB_SOCKET_SERVER=wdb \
+    WDB_WEB_PORT=1984 \
+    WDB_WEB_SERVER=localhost
+
+# Other requirements and recommendations
+# See https://github.com/$ODOO_SOURCE/blob/$ODOO_VERSION/debian/control
+RUN apt-get -qq update \
+    && apt-get install -yqq --no-install-recommends \
+        curl \
+    && curl -SLo wkhtmltox.deb https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/${WKHTMLTOPDF_VERSION}/wkhtmltox_${WKHTMLTOPDF_VERSION}-1.stretch_amd64.deb \
+    && echo "${WKHTMLTOPDF_CHECKSUM}  wkhtmltox.deb" | sha256sum -c - \
+    && apt-get install -yqq --no-install-recommends \
+        ./wkhtmltox.deb \
+        chromium \
+        ffmpeg \
+        fonts-liberation2 \
+        gettext \
+        git \
+        gnupg2 \
+        locales-all \
+        nano \
+        npm \
+        openssh-client \
+        telnet \
+        vim \
+        zlibc \
+    && echo 'deb http://apt.postgresql.org/pub/repos/apt/ stretch-pgdg main' >> /etc/apt/sources.list.d/postgresql.list \
+    && curl -SL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
+    && apt-get update \
+    && curl --silent -L --output geoipupdate_${GEOIP_UPDATER_VERSION}_linux_amd64.deb https://github.com/maxmind/geoipupdate/releases/download/v${GEOIP_UPDATER_VERSION}/geoipupdate_${GEOIP_UPDATER_VERSION}_linux_amd64.deb \
+    && dpkg -i geoipupdate_${GEOIP_UPDATER_VERSION}_linux_amd64.deb \
+    && rm geoipupdate_${GEOIP_UPDATER_VERSION}_linux_amd64.deb \
+    && apt-get autopurge -yqq \
+    && rm -Rf wkhtmltox.deb /var/lib/apt/lists/* /tmp/* \
+    && sync
+
+WORKDIR /opt/odoo
+COPY bin/* /usr/local/bin/
+COPY lib/doodbalib /usr/local/lib/python3.8/site-packages/doodbalib
+COPY build.d common/build.d
+COPY conf.d common/conf.d
+COPY entrypoint.d common/entrypoint.d
+RUN mkdir -p auto/addons auto/geoip custom/src/private \
+    && ln /usr/local/bin/direxec common/entrypoint \
+    && ln /usr/local/bin/direxec common/build \
+    && chmod -R a+rx common/entrypoint* common/build* /usr/local/bin \
+    && chmod -R a+rX /usr/local/lib/python3.8/site-packages/doodbalib \
+    && mv /etc/GeoIP.conf /opt/odoo/auto/geoip/GeoIP.conf \
+    && ln -s /opt/odoo/auto/geoip/GeoIP.conf /etc/GeoIP.conf \
+    && sed -i 's/.*DatabaseDirectory .*$/DatabaseDirectory \/opt\/odoo\/auto\/geoip\//g' /opt/odoo/auto/geoip/GeoIP.conf \
+    && sync
+
+# Doodba-QA dependencies in a separate virtualenv
+COPY qa /qa
+RUN python -m venv --system-site-packages /qa/venv \
+    && . /qa/venv/bin/activate \
+    && pip install \
+        click \
+        coverage \
+        flake8 \
+        pylint-odoo \
+        six \
+    && npm install --loglevel error --prefix /qa eslint \
+    && deactivate \
+    && mkdir -p /qa/artifacts
+
+ARG ODOO_SOURCE=OCA/OCB
+ARG ODOO_VERSION=15.0
+ENV ODOO_VERSION="$ODOO_VERSION"
+
+# Install Odoo hard & soft dependencies, and Doodba utilities
+# TODO: Add back pydevd-odoo once
+# https://github.com/trinhanhngoc/pydevd-odoo/issues/3 is fixed
+RUN build_deps=" \
+        build-essential \
+        libfreetype6-dev \
+        libfribidi-dev \
+        libghc-zlib-dev \
+        libharfbuzz-dev \
+        libjpeg-dev \
+        liblcms2-dev \
+        libldap2-dev \
+        libopenjp2-7-dev \
+        libpq-dev \
+        libsasl2-dev \
+        libtiff5-dev \
+        libwebp-dev \
+        libxml2-dev \
+        libxslt-dev \
+        tcl-dev \
+        tk-dev \
+        zlib1g-dev \
+    " \
+    && apt-get update \
+    && apt-get install -yqq --no-install-recommends $build_deps \
+    && pip install \
+        -r https://raw.githubusercontent.com/$ODOO_SOURCE/$ODOO_VERSION/requirements.txt \
+        'websocket-client~=0.56' \
+        astor \
+        # Install fix from https://github.com/acsone/click-odoo-contrib/pull/93
+        git+https://github.com/Tecnativa/click-odoo-contrib.git@fix-active-modules-hashing \
+        debugpy \
+        geoip2 \
+        git-aggregator \
+        inotify \
+        pdfminer.six \
+        pg_activity \
+        phonenumbers \
+        plumbum \
+        pudb \
+        python-magic \
+        watchdog \
+        wdb \
+    && (python3 -m compileall -q /usr/local/lib/python3.8/ || true) \
+    && apt-get purge -yqq $build_deps \
+    && apt-get autopurge -yqq \
+    && rm -Rf /var/lib/apt/lists/* /tmp/*
+
+# Metadata
+ARG VCS_REF
+ARG BUILD_DATE
+ARG VERSION
+LABEL org.label-schema.schema-version="$VERSION" \
+      org.label-schema.vendor=Tecnativa \
+      org.label-schema.license=Apache-2.0 \
+      org.label-schema.build-date="$BUILD_DATE" \
+      org.label-schema.vcs-ref="$VCS_REF" \
+      org.label-schema.vcs-url="https://github.com/Tecnativa/doodba"
+
+# Onbuild version, with all the magic
+FROM base AS onbuild
+
+# Enable setting custom uids for odoo user during build of scaffolds
+ONBUILD ARG UID=1000
+ONBUILD ARG GID=1000
+
+# Enable Odoo user and filestore
+ONBUILD RUN groupadd -g $GID odoo -o \
+    && useradd -l -md /home/odoo -s /bin/false -u $UID -g $GID odoo \
+    && mkdir -p /var/lib/odoo \
+    && chown -R odoo:odoo /var/lib/odoo /qa/artifacts \
+    && chmod a=rwX /qa/artifacts \
+    && sync
+
+# Subimage triggers
+ONBUILD ENTRYPOINT ["/opt/odoo/common/entrypoint"]
+ONBUILD CMD ["/usr/local/bin/odoo"]
+ONBUILD ARG AGGREGATE=true
+ONBUILD ARG DEFAULT_REPO_PATTERN="https://github.com/OCA/{}.git"
+ONBUILD ARG DEFAULT_REPO_PATTERN_ODOO="https://github.com/OCA/OCB.git"
+ONBUILD ARG DEPTH_DEFAULT=1
+ONBUILD ARG DEPTH_MERGE=100
+ONBUILD ARG CLEAN=true
+ONBUILD ARG COMPILE=true
+ONBUILD ARG FONT_MONO="Liberation Mono"
+ONBUILD ARG FONT_SANS="Liberation Sans"
+ONBUILD ARG FONT_SERIF="Liberation Serif"
+ONBUILD ARG PIP_INSTALL_ODOO=true
+ONBUILD ARG ADMIN_PASSWORD=admin
+ONBUILD ARG SMTP_SERVER=smtp
+ONBUILD ARG SMTP_PORT=25
+ONBUILD ARG SMTP_USER=false
+ONBUILD ARG SMTP_PASSWORD=false
+ONBUILD ARG SMTP_SSL=false
+ONBUILD ARG EMAIL_FROM=""
+ONBUILD ARG PROXY_MODE=false
+ONBUILD ARG WITHOUT_DEMO=all
+ONBUILD ARG PGUSER=odoo
+ONBUILD ARG PGPASSWORD=odoopassword
+ONBUILD ARG PGHOST=db
+ONBUILD ARG PGPORT=5432
+ONBUILD ARG PGDATABASE=prod
+
+# Config variables
+ONBUILD ENV ADMIN_PASSWORD="$ADMIN_PASSWORD" \
+            DEFAULT_REPO_PATTERN="$DEFAULT_REPO_PATTERN" \
+            DEFAULT_REPO_PATTERN_ODOO="$DEFAULT_REPO_PATTERN_ODOO" \
+            UNACCENT="$UNACCENT" \
+            PGUSER="$PGUSER" \
+            PGPASSWORD="$PGPASSWORD" \
+            PGHOST="$PGHOST" \
+            PGPORT=$PGPORT \
+            PGDATABASE="$PGDATABASE" \
+            PROXY_MODE="$PROXY_MODE" \
+            SMTP_SERVER="$SMTP_SERVER" \
+            SMTP_PORT=$SMTP_PORT \
+            SMTP_USER="$SMTP_USER" \
+            SMTP_PASSWORD="$SMTP_PASSWORD" \
+            SMTP_SSL="$SMTP_SSL" \
+            EMAIL_FROM="$EMAIL_FROM" \
+            WITHOUT_DEMO="$WITHOUT_DEMO"
+ONBUILD ARG LOCAL_CUSTOM_DIR=./custom
+ONBUILD COPY --chown=root:odoo $LOCAL_CUSTOM_DIR /opt/odoo/custom
+
+# https://docs.python.org/3/library/logging.html#levels
+ONBUILD ARG LOG_LEVEL=INFO
+ONBUILD RUN mkdir -p /opt/odoo/custom/ssh \
+            && ln -s /opt/odoo/custom/ssh ~root/.ssh \
+            && chmod -R u=rwX,go= /opt/odoo/custom/ssh \
+            && sync
+ONBUILD ARG DB_VERSION=latest
+ONBUILD RUN /opt/odoo/common/build && sync
+ONBUILD VOLUME ["/var/lib/odoo"]
+ONBUILD USER odoo

--- a/15.0.Dockerfile
+++ b/15.0.Dockerfile
@@ -93,8 +93,8 @@ RUN python -m venv --system-site-packages /qa/venv \
     && deactivate \
     && mkdir -p /qa/artifacts
 
-ARG ODOO_SOURCE=OCA/OCB
-ARG ODOO_VERSION=15.0
+ARG ODOO_SOURCE=odoo/odoo
+ARG ODOO_VERSION=saas-14.5
 ENV ODOO_VERSION="$ODOO_VERSION"
 
 # Install Odoo hard & soft dependencies, and Doodba utilities
@@ -176,7 +176,7 @@ ONBUILD ENTRYPOINT ["/opt/odoo/common/entrypoint"]
 ONBUILD CMD ["/usr/local/bin/odoo"]
 ONBUILD ARG AGGREGATE=true
 ONBUILD ARG DEFAULT_REPO_PATTERN="https://github.com/OCA/{}.git"
-ONBUILD ARG DEFAULT_REPO_PATTERN_ODOO="https://github.com/OCA/OCB.git"
+ONBUILD ARG DEFAULT_REPO_PATTERN_ODOO="https://github.com/odoo/odoo.git"
 ONBUILD ARG DEPTH_DEFAULT=1
 ONBUILD ARG DEPTH_MERGE=100
 ONBUILD ARG CLEAN=true

--- a/README.md
+++ b/README.md
@@ -394,8 +394,8 @@ server-tools:
 # Custom repositories
 ENV:
   DEFAULT_REPO_PATTERN: https://github.com/Tecnativa/{}.git
-  ODOO_VERSION: 14.0-new-feature
-some-repo: # Cloned from https://github.com/Tecnativa/some-repo.git branch 14.0-new-feature
+  ODOO_VERSION: 15.0-new-feature
+some-repo: # Cloned from https://github.com/Tecnativa/some-repo.git branch 15.0-new-feature
   - some_custom_module
 ```
 

--- a/hooks/build
+++ b/hooks/build
@@ -20,8 +20,6 @@ for target, suffix in (("base", ""), ("onbuild", "-onbuild")):
         "VCS_REF=%s" % COMMIT,
         "--build-arg",
         "BUILD_DATE=%s" % date().strip(),
-        "--build-arg",
-        "ODOO_VERSION=%s" % VERSION,
         "--tag",
         image_name,
         "--target",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -16,7 +16,7 @@ logging.basicConfig(level=logging.DEBUG)
 
 DIR = dirname(__file__)
 ODOO_PREFIX = ("odoo", "--stop-after-init", "--workers=0")
-ODOO_VERSIONS = frozenset(environ.get("DOCKER_TAG", "11.0 12.0 13.0 14.0").split())
+ODOO_VERSIONS = frozenset(environ.get("DOCKER_TAG", "11.0 12.0 13.0 14.0 15.0").split())
 PG_VERSIONS = frozenset(environ.get("PG_VERSIONS", "13").split())
 SCAFFOLDINGS_DIR = join(DIR, "scaffoldings")
 GEIOP_CREDENTIALS_PROVIDED = environ.get("GEOIP_LICENSE_KEY", False) and environ.get(
@@ -28,7 +28,7 @@ GEIOP_CREDENTIALS_PROVIDED = environ.get("GEOIP_LICENSE_KEY", False) and environ
 # preparing the pre-release for the next version of Odoo, which hasn't been
 # released yet.
 prerelease_skip = unittest.skipIf(
-    ODOO_VERSIONS == {"14.0"}, "Tests not supported in pre-release"
+    ODOO_VERSIONS == {"15.0"}, "Tests not supported in pre-release"
 )
 
 


### PR DESCRIPTION
Prepares base for v15, also making the necessary changes to make it work with the current `saas-14.5`. Once the branch `15.0` is available in `OCA/OCB`, we can just revert 433dbb3

@Tecnativa
TT17396