### PR TITLE
[FIX] 13.0,14.0: use eslint version lower than 8

### DIFF
--- a/13.0.Dockerfile
+++ b/13.0.Dockerfile
@@ -93,7 +93,7 @@ RUN python -m venv --system-site-packages /qa/venv \
         flake8 \
         pylint-odoo \
         six \
-    && npm install --loglevel error --prefix /qa eslint \
+    && npm install --loglevel error --prefix /qa 'eslint@<8' \
     && deactivate \
     && mkdir -p /qa/artifacts \
     && git clone --depth 1 $MQT /qa/mqt

--- a/14.0.Dockerfile
+++ b/14.0.Dockerfile
@@ -89,7 +89,7 @@ RUN python -m venv --system-site-packages /qa/venv \
         flake8 \
         pylint-odoo \
         six \
-    && npm install --loglevel error --prefix /qa eslint \
+    && npm install --loglevel error --prefix /qa 'eslint@<8' \
     && deactivate \
     && mkdir -p /qa/artifacts
 


### PR DESCRIPTION
eslint 8.0.0 with node v10.x produces the following error message:
```
doodba INFO: Executing /qa/node_modules/.bin/eslint --version
Oops! Something went wrong! :(
ESLint: 8.0.0
TypeError: Module.createRequire is not a function
    at Object.<anonymous> (/qa/node_modules/@eslint/eslintrc/dist/eslintrc.cjs:2359:26)
    at Module._compile (/qa/node_modules/v8-compile-cache/v8-compile-cache.js:192:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
    at Module.require (internal/modules/cjs/loader.js:692:17)
    at require (/qa/node_modules/v8-compile-cache/v8-compile-cache.js:159:20)
    at Object.<anonymous> (/qa/node_modules/eslint/lib/cli-engine/cli-engine.js:33:5)
    at Module._compile (/qa/node_modules/v8-compile-cache/v8-compile-cache.js:192:30)
```