### PR TITLE
[IMP] add missing flanker soft dependency

### DIFF
--- a/15.0.Dockerfile
+++ b/15.0.Dockerfile
@@ -125,6 +125,7 @@ RUN build_deps=" \
         # Install fix from https://github.com/acsone/click-odoo-contrib/pull/93
         git+https://github.com/Tecnativa/click-odoo-contrib.git@fix-active-modules-hashing \
         debugpy \
+        flanker \
         geoip2 \
         git-aggregator \
         inotify \


### PR DESCRIPTION
In Odoo 15.0, support for flanker has been included.

See https://github.com/odoo/odoo/blob/a7f7233e0eae8ee101d745a9813cba930fd03dcb/addons/mail/tools/mail_validation.py#L11-L27

Without this, we get these logs:

    odoo.addons.mail.tools.mail_validation: The `flanker` Python module is not installed,so email validation fallback to email_normalize. Use 'pip install flanker' to install it

@moduon MT-221