### PR TITLE
[FIX] missing flanker dependencies

### DIFF
--- a/15.0.Dockerfile
+++ b/15.0.Dockerfile
@@ -125,7 +125,7 @@ RUN build_deps=" \
         # Install fix from https://github.com/acsone/click-odoo-contrib/pull/93
         git+https://github.com/Tecnativa/click-odoo-contrib.git@fix-active-modules-hashing \
         debugpy \
-        flanker \
+        flanker[validator] \
         geoip2 \
         git-aggregator \
         inotify \


### PR DESCRIPTION
As seen in https://github.com/mailgun/flanker/pull/164, for using flanker for validation, one needs additional dependencies.

That's Odoo's use case, so without this patch it fails with:

```
2022-02-02 12:26:32,758 29 WARNING odoo odoo.modules.loading: Module crm demo data failed to install, installed without demo data
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/tools/convert.py", line 680, in _tag_root
    f(rec)
  File "/opt/odoo/custom/src/odoo/odoo/tools/convert.py", line 333, in _tag_function
    _eval_xml(self, rec, env)
  File "/opt/odoo/custom/src/odoo/odoo/tools/convert.py", line 204, in _eval_xml
    return odoo.api.call_kw(model, method_name, args, kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 464, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 451, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/opt/odoo/auto/addons/crm/models/crm_lead.py", line 897, in action_set_lost
    res = self.action_archive()
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 5062, in action_archive
    return self.filtered(lambda record: record[self._active_name]).toggle_active()
  File "/opt/odoo/auto/addons/crm/models/crm_lead.py", line 885, in toggle_active
    res = super(Lead, self).toggle_active()
  File "/opt/odoo/auto/addons/mail/models/mail_activity_mixin.py", line 337, in toggle_active
    return super(MailActivityMixin, self).toggle_active()
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 5055, in toggle_active
    active_recs[self._active_name] = False
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 5891, in __setitem__
    return self._fields[key].__set__(self, value)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1217, in __set__
    records.write({self.name: write_value})
  File "/opt/odoo/auto/addons/crm/models/crm_lead.py", line 685, in write
    self._handle_won_lost(vals)
  File "/opt/odoo/auto/addons/crm/models/crm_lead.py", line 803, in _handle_won_lost
    leads_reach_lost._pls_increment_frequencies(to_state='lost')
  File "/opt/odoo/auto/addons/crm/models/crm_lead.py", line 1998, in _pls_increment_frequencies
    new_frequencies_by_team, existing_frequencies_by_team = self._pls_prepare_update_frequency_table(target_state=from_state or to_state)
  File "/opt/odoo/auto/addons/crm/models/crm_lead.py", line 2156, in _pls_prepare_update_frequency_table
    leads_values_dict = pls_leads._pls_get_lead_pls_values(domain=domain)
  File "/opt/odoo/auto/addons/crm/models/crm_lead.py", line 2376, in _pls_get_lead_pls_values
    self.flush(['probability'])
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 5644, in flush
    self.recompute(fnames, records=records)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 6124, in recompute
    process(field)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 6095, in process
    field.recompute(recs)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1243, in recompute
    self.compute_value(recs)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1265, in compute_value
    records._compute_field_value(self)
  File "/opt/odoo/auto/addons/mail/models/mail_thread.py", line 410, in _compute_field_value
    return super()._compute_field_value(field)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 4256, in _compute_field_value
    getattr(self, field.compute)()
  File "/opt/odoo/auto/addons/crm/models/crm_lead.py", line 453, in _compute_probabilities
    lead_probabilities = self._pls_get_naive_bayes_probabilities()
  File "/opt/odoo/auto/addons/crm/models/crm_lead.py", line 1876, in _pls_get_naive_bayes_probabilities
    leads_values_dict = self._pls_get_lead_pls_values(domain=domain)
  File "/opt/odoo/auto/addons/crm/models/crm_lead.py", line 2421, in _pls_get_lead_pls_values
    value = lead[field].id if isinstance(lead[field], models.BaseModel) else lead[field]
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 5882, in __getitem__
    return self._fields[key].__get__(self, type(self))
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1054, in __get__
    self.recompute(record)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1243, in recompute
    self.compute_value(recs)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1265, in compute_value
    records._compute_field_value(self)
  File "/opt/odoo/auto/addons/mail/models/mail_thread.py", line 410, in _compute_field_value
    return super()._compute_field_value(field)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 4256, in _compute_field_value
    getattr(self, field.compute)()
  File "/opt/odoo/auto/addons/crm/models/crm_lead.py", line 439, in _compute_email_state
    if mail_validation.mail_validate(email):
  File "/opt/odoo/auto/addons/mail/tools/mail_validation.py", line 17, in mail_validate
    return bool(address.validate_address(email))
  File "/usr/local/lib/python3.8/site-packages/flanker/utils.py", line 64, in wrapper
    return_value = f(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/flanker/addresslib/address.py", line 312, in validate_address
    exchanger, mx_metrics = mail_exchanger_lookup(paddr.hostname, metrics=True)
  File "/usr/local/lib/python3.8/site-packages/flanker/utils.py", line 64, in wrapper
    return_value = f(*args, **kwargs)
  File "/usr/local/lib/python3.8/site-packages/flanker/addresslib/validate.py", line 146, in mail_exchanger_lookup
    in_cache, cache_value = lookup_exchanger_in_cache(domain)
  File "/usr/local/lib/python3.8/site-packages/flanker/addresslib/validate.py", line 188, in lookup_exchanger_in_cache
    lookup = _get_mx_cache()[domain]
  File "/usr/local/lib/python3.8/site-packages/flanker/addresslib/validate.py", line 238, in _get_mx_cache
    from flanker.addresslib.drivers.redis_driver import RedisCache
  File "/usr/local/lib/python3.8/site-packages/flanker/addresslib/drivers/redis_driver.py", line 3, in <module>
    import redis
ModuleNotFoundError: No module named 'redis'
```

@moduon MT-221