### PR TITLE
feat: add pyOpenSSL by default

### DIFF
--- a/14.0.Dockerfile
+++ b/14.0.Dockerfile
@@ -135,6 +135,7 @@ RUN build_deps=" \
         phonenumbers \
         plumbum \
         pudb \
+        pyOpenSSL \
         python-magic \
         watchdog \
         wdb \

--- a/15.0.Dockerfile
+++ b/15.0.Dockerfile
@@ -134,6 +134,7 @@ RUN build_deps=" \
         phonenumbers \
         plumbum \
         pudb \
+        pyOpenSSL \
         python-magic \
         watchdog \
         wdb \


### PR DESCRIPTION
This is one Odoo lazy dependency since v14.

https://github.com/odoo/odoo/blob/d4de2cfe64f42a711816bfbbc88a371519eee9da/addons/l10n_es_edi_sii/__manifest__.py#L46

@moduon MT-282