### PR TITLE
[IMP] 15.0: generate flanker cached tables during build

### DIFF
--- a/15.0.Dockerfile
+++ b/15.0.Dockerfile
@@ -139,6 +139,9 @@ RUN build_deps=" \
         watchdog \
         wdb \
     && (python3 -m compileall -q /usr/local/lib/python3.8/ || true) \
+    # generate flanker cached tables during install when /usr/local/lib/ is still intended to be written to
+    # https://github.com/Tecnativa/doodba/issues/486
+    && python3 -c 'from flanker.addresslib import address' >/dev/null 2>&1 \
     && apt-get purge -yqq $build_deps \
     && apt-get autopurge -yqq \
     && rm -Rf /var/lib/apt/lists/* /tmp/*


### PR DESCRIPTION
fix for #486 