### PR TITLE
Fix permission error during build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,7 @@ jobs:
         run: echo "$HOME/.local/bin" >> $GITHUB_PATH
       - run: poetry install
       # Build images
-      - run: poetry run ./hooks/build
+      - run: poetry run python ./hooks/build
       # Test
       - run: poetry run python -m unittest -v tests
       # Push


### PR DESCRIPTION

This a fix for the below error:

  PermissionError

  [Errno 13] Permission denied: './hooks/build'

  at /opt/hostedtoolcache/Python/3.10.2/x64/lib/python3.10/os.py:597 in _execvpe
       593│         argrest = (args,)
       594│         env = environ
       595│ 
       596│     if path.dirname(file):
    →  597│         exec_func(file, *argrest)
       598│         return
       599│     saved_exc = None
       600│     path_list = get_exec_path(env)
       601│     if name != 'nt':
Error: Process completed with exit code 1.


![image](https://user-images.githubusercontent.com/5569632/160308244-c33d39e6-8cef-406c-883f-d9eeaa652525.png)
