### PR TITLE
feat: update db expiration date when preparing db

### DIFF
--- a/bin/preparedb
+++ b/bin/preparedb
@@ -11,6 +11,9 @@ import click_odoo
 def main(env):
     """Set report.url in the database to be pointing at localhost."""
     env["ir.config_parameter"].set_param("report.url", "http://localhost:8069")
+    env["ir.config_parameter"].set_param(
+        "database.expiration_date", "3000-01-30 00:00:00"
+    )
     env.cr.commit()
 
 


### PR DESCRIPTION
This script is called when using `invoke preparedb` in develop mode.

If developing enterprise code, this avoids an unnecessary warning.