### PR TITLE
[FIX] git-aggregator: use git-aggregator < 3.0.0 for V11.0 and V12.0

### DIFF
--- a/11.0.Dockerfile
+++ b/11.0.Dockerfile
@@ -82,7 +82,7 @@ RUN pip install \
         astor \
         # Install fix from https://github.com/acsone/click-odoo-contrib/pull/93
         git+https://github.com/Tecnativa/click-odoo-contrib.git@fix-active-modules-hashing \
-        git-aggregator \
+        "git-aggregator<3.0.0" \
         "pg_activity<2.0.0" \
         plumbum \
         ptvsd \

--- a/12.0.Dockerfile
+++ b/12.0.Dockerfile
@@ -77,7 +77,7 @@ RUN pip install \
         astor \
         # Install fix from https://github.com/acsone/click-odoo-contrib/pull/93
         git+https://github.com/Tecnativa/click-odoo-contrib.git@fix-active-modules-hashing \
-        git-aggregator \
+        "git-aggregator<3.0.0" \
         "pg_activity<2.0.0" \
         plumbum \
         ptvsd \


### PR DESCRIPTION
filter=blob:none is not compatible with older git version in debian stretch

After git-aggregator 3.0.0 got relased our nightly CI builds failed for 11.0 and 12.0 with:
```
(ERROR) [21:20:47] git_aggregator.repo  misc-addons   /opt/odoo/custom/src/misc-addons> error calling ('git', 'clone', '--filter=blob:none', '--depth', '1', 'https://github.com/itpp-labs/misc-addons.git', '/opt/odoo/custom/src/misc-addons')
error: unknown option `filter=blob:none'
```

Info @wt-io-it