### PR TITLE
Revert "[FIX] git-aggregator: use git-aggregator < 3.0.0 for V11.0 and V12.0"

### DIFF
--- a/11.0.Dockerfile
+++ b/11.0.Dockerfile
@@ -82,7 +82,7 @@ RUN pip install \
         astor \
         # Install fix from https://github.com/acsone/click-odoo-contrib/pull/93
         git+https://github.com/Tecnativa/click-odoo-contrib.git@fix-active-modules-hashing \
-        "git-aggregator<3.0.0" \
+        git-aggregator \
         "pg_activity<2.0.0" \
         plumbum \
         ptvsd \

--- a/12.0.Dockerfile
+++ b/12.0.Dockerfile
@@ -77,7 +77,7 @@ RUN pip install \
         astor \
         # Install fix from https://github.com/acsone/click-odoo-contrib/pull/93
         git+https://github.com/Tecnativa/click-odoo-contrib.git@fix-active-modules-hashing \
-        "git-aggregator<3.0.0" \
+        git-aggregator \
         "pg_activity<2.0.0" \
         plumbum \
         ptvsd \


### PR DESCRIPTION
Reverts Tecnativa/doodba#523

It shouldn't be needed with latest git-aggregator version (3.0.1).