### PR TITLE
[FIX][16.0] click-odoo-contrib so out of date it doesnt understand 16.0

### DIFF
--- a/15.0.Dockerfile
+++ b/15.0.Dockerfile
@@ -120,8 +120,7 @@ RUN build_deps=" \
         -r https://raw.githubusercontent.com/$ODOO_SOURCE/$ODOO_VERSION/requirements.txt \
         'websocket-client~=0.56' \
         astor \
-        # Install fix from https://github.com/acsone/click-odoo-contrib/pull/93
-        git+https://github.com/Tecnativa/click-odoo-contrib.git@fix-active-modules-hashing \
+        click-odoo-contrib \
         debugpy \
         pydevd-odoo \
         flanker[validator] \

--- a/16.0.Dockerfile
+++ b/16.0.Dockerfile
@@ -120,8 +120,7 @@ RUN build_deps=" \
         -r https://raw.githubusercontent.com/$ODOO_SOURCE/$ODOO_VERSION/requirements.txt \
         'websocket-client~=0.56' \
         astor \
-        # Install fix from https://github.com/acsone/click-odoo-contrib/pull/93
-        git+https://github.com/Tecnativa/click-odoo-contrib.git@fix-active-modules-hashing \
+        click-odoo-contrib \
         debugpy \
         pydevd-odoo \
         flanker[validator] \

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -284,6 +284,8 @@ class ScaffoldingCase(unittest.TestCase):
             ODOO_PREFIX + ("--init", "base"),
             # Auto updater must work
             ("click-odoo-update",),
+            # Auto updater must work, ignoring core addons
+            ("click-odoo-update", "--ignore-core-addons"),
             # Needed tools exist
             ("curl", "--version"),
             ("git", "--version"),


### PR DESCRIPTION
The 16.0 Dockerfile is referencing an older fork of click-odoo-contrib, resulting in click-odoo-update not actually being functional out of the box on a 16.0 install, throwing the following error:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/click_odoo/env_options.py", line 191, in _invoke
    with self.environment_manager(
  File "/usr/local/lib/python3.8/contextlib.py", line 113, in __enter__
    return next(self.gen)
  File "/usr/local/lib/python3.8/site-packages/click_odoo_contrib/update.py", line 277, in OdooEnvironmentWithUpdate
    ignore_addons.update(core_addons[odoo.release.series])
KeyError: '16.0'
Error: '16.0'
```

Plus 16.0 requires a newer version anyway due to https://github.com/acsone/click-odoo-contrib/pull/119

Reading https://github.com/acsone/click-odoo-contrib/pull/93, as far as I can tell this fork is no longer relevant?