### PR TITLE
[FIX] 1[12].0: use archive for debian stretch packages

### DIFF
--- a/11.0.Dockerfile
+++ b/11.0.Dockerfile
@@ -34,6 +34,9 @@ ENV DB_FILTER=.* \
     WDB_WEB_PORT=1984 \
     WDB_WEB_SERVER=localhost
 
+# Debian stretch was moved to archive (and stretch-updates does not exist in archive)
+RUN sed -i 's,http://deb.debian.org,http://archive.debian.org,g;s,http://security.debian.org,http://archive.debian.org,g;s,\(.*stretch-updates\),#\1,' /etc/apt/sources.list
+
 # Other requirements and recommendations to run Odoo
 # See https://github.com/$ODOO_SOURCE/blob/$ODOO_VERSION/debian/control
 RUN apt-get -qq update \

--- a/12.0.Dockerfile
+++ b/12.0.Dockerfile
@@ -34,6 +34,9 @@ ENV DB_FILTER=.* \
     WDB_WEB_PORT=1984 \
     WDB_WEB_SERVER=localhost
 
+# Debian stretch was moved to archive (and stretch-updates does not exist in archive)
+RUN sed -i 's,http://deb.debian.org,http://archive.debian.org,g;s,http://security.debian.org,http://archive.debian.org,g;s,\(.*stretch-updates\),#\1,' /etc/apt/sources.list
+
 # Other requirements and recommendations to run Odoo
 # See https://github.com/$ODOO_SOURCE/blob/$ODOO_VERSION/debian/control
 RUN apt-get -qq update \


### PR DESCRIPTION
Fix building images with debian stretch. Depending on the selected mirror we saw more and more issues with building the stretch images.

```
#6 1.419 Reading package lists...
#6 1.437 W: The repository 'http://security.debian.org/debian-security stretch/updates Release' does not have a Release file.
#6 1.437 W: The repository 'http://deb.debian.org/debian stretch Release' does not have a Release file.
#6 1.437 W: The repository 'http://deb.debian.org/debian stretch-updates Release' does not have a Release file.
#6 1.437 E: Failed to fetch http://security.debian.org/debian-security/dists/stretch/updates/main/binary-amd64/Packages  404  Not Found
#6 1.437 E: Failed to fetch http://deb.debian.org/debian/dists/stretch/main/binary-amd64/Packages  404  Not Found
#6 1.437 E: Failed to fetch http://deb.debian.org/debian/dists/stretch-updates/main/binary-amd64/Packages  404  Not Found
#6 1.437 E: Some index files failed to download. They have been ignored, or old ones used instead.
```

It seems like the mirrors are slowly removing the packages for debian stretch.

In this pull request:
* `stretch-updates main` gets deactivated (it is not present in archive)
* `stretch main` is fetched from archive
* `security.debian.org stretch/updates` is fetched from archive

Info @wt-io-it