### PR TITLE
[FIX] 11.0: use execjs <2.9.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,6 +63,9 @@ jobs:
       - run: pip install poetry
       - name: Patch $PATH
         run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+      # override pyyaml to 5.3.1 as PIP_CONSTRAINT does not work for poetry
+      # to get rid of AttributeError: cython_sources when installing pyyaml
+      - run: poetry add pyyaml==5.3.1
       - run: poetry install
       # Build images
       - run: poetry run ./hooks/build

--- a/11.0.Dockerfile
+++ b/11.0.Dockerfile
@@ -77,7 +77,8 @@ RUN ln -s /usr/bin/nodejs /usr/local/bin/node \
     && rm -Rf ~/.npm /tmp/*
 
 # Special case to get bootstrap-sass, required by Odoo for Sass assets
-RUN gem install --no-rdoc --no-ri --no-update-sources autoprefixer-rails --version '<9.8.6' \
+RUN gem install --no-rdoc --no-ri --no-update-sources execjs --version '<2.9.1' \
+    && gem install --no-rdoc --no-ri --no-update-sources autoprefixer-rails --version '<9.8.6' \
     && gem install --no-rdoc --no-ri --no-update-sources bootstrap-sass --version '<3.4' \
     && rm -Rf ~/.gem /var/lib/gems/*/cache/
 


### PR DESCRIPTION
to avoid "execjs requires Ruby version >= 2.5.0." errors.

execjs seens to have a new tag 2.9.1 that fails installing as a dependency of autoprefixer-rails on our CI with the following error:
```
...
#14 [base  5/18] RUN gem install --no-rdoc --no-ri --no-update-sources autoprefixer-rails --version '<9.8.6'     && gem install --no-rdoc --no-ri --no-update-sources bootstrap-sass --version '<3.4'     && rm -Rf ~/.gem /var/lib/gems/*/cache/
#14 55.10 ERROR:  Error installing autoprefixer-rails:
#14 55.10 	execjs requires Ruby version >= 2.5.0.
#14 ERROR: executor failed running [/bin/sh -c gem install --no-rdoc --no-ri --no-update-sources autoprefixer-rails --version '<9.8.6'     && gem install --no-rdoc --no-ri --no-update-sources bootstrap-sass --version '<3.4'     && rm -Rf ~/.gem /var/lib/gems/*/cache/]: runc did not terminate sucessfully
------
 > [base  5/18] RUN gem install --no-rdoc --no-ri --no-update-sources autoprefixer-rails --version '<9.8.6'     && gem install --no-rdoc --no-ri --no-update-sources bootstrap-sass --version '<3.4'     && rm -Rf ~/.gem /var/lib/gems/*/cache/:
#14 55.10 ERROR:  Error installing autoprefixer-rails:
#14 55.10 	execjs requires Ruby version >= 2.5.0.
```

Pinning the version to <2.9.1 fixes the issue for 11.0.Dockerfile

Info @wt-io-it