### PR TITLE
[IMP] Use python 3.10 in v16.0

### DIFF
--- a/16.0.Dockerfile
+++ b/16.0.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim-bullseye AS base
+FROM python:3.10-slim-bullseye AS base
 
 EXPOSE 8069 8072
 
@@ -64,7 +64,7 @@ RUN apt-get -qq update \
 
 WORKDIR /opt/odoo
 COPY bin/* /usr/local/bin/
-COPY lib/doodbalib /usr/local/lib/python3.8/site-packages/doodbalib
+COPY lib/doodbalib /usr/local/lib/python3.10/site-packages/doodbalib
 COPY build.d common/build.d
 COPY conf.d common/conf.d
 COPY entrypoint.d common/entrypoint.d
@@ -72,7 +72,7 @@ RUN mkdir -p auto/addons auto/geoip custom/src/private \
     && ln /usr/local/bin/direxec common/entrypoint \
     && ln /usr/local/bin/direxec common/build \
     && chmod -R a+rx common/entrypoint* common/build* /usr/local/bin \
-    && chmod -R a+rX /usr/local/lib/python3.8/site-packages/doodbalib \
+    && chmod -R a+rX /usr/local/lib/python3.10/site-packages/doodbalib \
     && cp -a /etc/GeoIP.conf /etc/GeoIP.conf.orig \
     && mv /etc/GeoIP.conf /opt/odoo/auto/geoip/GeoIP.conf \
     && ln -s /opt/odoo/auto/geoip/GeoIP.conf /etc/GeoIP.conf \
@@ -136,7 +136,7 @@ RUN build_deps=" \
         python-magic \
         watchdog \
         wdb \
-    && (python3 -m compileall -q /usr/local/lib/python3.8/ || true) \
+    && (python3 -m compileall -q /usr/local/lib/python3.10/ || true) \
     # generate flanker cached tables during install when /usr/local/lib/ is still intended to be written to
     # https://github.com/Tecnativa/doodba/issues/486
     && python3 -c 'from flanker.addresslib import address' >/dev/null 2>&1 \

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -93,7 +93,7 @@ class ScaffoldingCase(unittest.TestCase):
     def test_addons_filtered(self):
         """Test addons filtering with ``ONLY`` keyword in ``addons.yaml``."""
         project_dir = join(SCAFFOLDINGS_DIR, "dotd")
-        for sub_env in matrix(odoo_skip={"17.0"}):
+        for sub_env in matrix():
             self.compose_test(
                 project_dir,
                 dict(sub_env, DBNAME="prod"),
@@ -367,7 +367,7 @@ class ScaffoldingCase(unittest.TestCase):
 
     def test_dotd(self):
         """Test environment with common ``*.d`` directories."""
-        for sub_env in matrix(odoo_skip={"17.0"}):
+        for sub_env in matrix():
             self.compose_test(
                 join(SCAFFOLDINGS_DIR, "dotd"),
                 sub_env,


### PR DESCRIPTION
Due to this fixes (https://github.com/Tecnativa/doodba/pull/575), we can now use python 3.10 in v16.0.
CC @Tecnativa TT45957