### PR TITLE
fix: remove flanker from py3.10 flavors

### DIFF
--- a/16.0.Dockerfile
+++ b/16.0.Dockerfile
@@ -123,7 +123,6 @@ RUN build_deps=" \
         click-odoo-contrib \
         debugpy \
         pydevd-odoo \
-        flanker[validator] \
         geoip2 \
         "git-aggregator<3.0.0" \
         inotify \
@@ -137,9 +136,6 @@ RUN build_deps=" \
         watchdog \
         wdb \
     && (python3 -m compileall -q /usr/local/lib/python3.10/ || true) \
-    # generate flanker cached tables during install when /usr/local/lib/ is still intended to be written to
-    # https://github.com/Tecnativa/doodba/issues/486
-    && python3 -c 'from flanker.addresslib import address' >/dev/null 2>&1 \
     && apt-get purge -yqq $build_deps \
     && apt-get autopurge -yqq \
     && rm -Rf /var/lib/apt/lists/* /tmp/*

--- a/17.0.Dockerfile
+++ b/17.0.Dockerfile
@@ -123,7 +123,6 @@ RUN build_deps=" \
         click-odoo-contrib \
         debugpy \
         pydevd-odoo \
-        flanker[validator] \
         geoip2 \
         "git-aggregator<3.0.0" \
         inotify \
@@ -137,9 +136,6 @@ RUN build_deps=" \
         watchdog \
         wdb \
     && (python3 -m compileall -q /usr/local/lib/python3.10/ || true) \
-    # generate flanker cached tables during install when /usr/local/lib/ is still intended to be written to
-    # https://github.com/Tecnativa/doodba/issues/486
-    && python3 -c 'from flanker.addresslib import address' >/dev/null 2>&1 \
     && apt-get purge -yqq $build_deps \
     && apt-get autopurge -yqq \
     && rm -Rf /var/lib/apt/lists/* /tmp/*


### PR DESCRIPTION
After merging https://github.com/Tecnativa/doodba/pull/577, we started getting build failures due to https://github.com/mailgun/flanker/issues/261.

We should better remove that dependency, which is very outdated and not much maintained, and is optional for Odoo.

<details>
<summary>Failure logs when installing `crm`</summary>

```
2023-11-15 13:24:16,112 62 INFO odoo odoo.modules.loading: loading crm/data/crm_lead_demo.xml 
2023-11-15 13:24:16,653 62 WARNING odoo odoo.modules.loading: Module crm demo data failed to install, installed without demo data 
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/tools/convert.py", line 698, in _tag_root
    f(rec)
  File "/opt/odoo/custom/src/odoo/odoo/tools/convert.py", line 333, in _tag_function
    _eval_xml(self, rec, env)
  File "/opt/odoo/custom/src/odoo/odoo/tools/convert.py", line 204, in _eval_xml
    return odoo.api.call_kw(model, method_name, args, kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 466, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/opt/odoo/custom/src/odoo/odoo/api.py", line 453, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/opt/odoo/auto/addons/crm/models/crm_lead.py", line 965, in action_set_lost
    res = self.action_archive()
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 5032, in action_archive
    return self.filtered(lambda record: record[self._active_name]).toggle_active()
  File "/opt/odoo/auto/addons/crm/models/crm_lead.py", line 953, in toggle_active
    res = super(Lead, self).toggle_active()
  File "/opt/odoo/auto/addons/mail/models/mail_activity_mixin.py", line 337, in toggle_active
    return super(MailActivityMixin, self).toggle_active()
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 5025, in toggle_active
    active_recs[self._active_name] = False
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 5906, in __setitem__
    return self._fields[key].__set__(self, value)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1320, in __set__
    records.write({self.name: write_value})
  File "/opt/odoo/auto/addons/crm/models/crm_lead.py", line 742, in write
    self._handle_won_lost(vals)
  File "/opt/odoo/auto/addons/crm/models/crm_lead.py", line 869, in _handle_won_lost
    leads_reach_lost._pls_increment_frequencies(to_state='lost')
  File "/opt/odoo/auto/addons/crm/models/crm_lead.py", line 2202, in _pls_increment_frequencies
    new_frequencies_by_team, existing_frequencies_by_team = self._pls_prepare_update_frequency_table(target_state=from_state or to_state)
  File "/opt/odoo/auto/addons/crm/models/crm_lead.py", line 2362, in _pls_prepare_update_frequency_table
    leads_values_dict = pls_leads._pls_get_lead_pls_values(domain=domain)
  File "/opt/odoo/auto/addons/crm/models/crm_lead.py", line 2582, in _pls_get_lead_pls_values
    self.flush_model()
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 5597, in flush_model
    self._recompute_model(fnames)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 6171, in _recompute_model
    self._recompute_field(field)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 6199, in _recompute_field
    field.recompute(records)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1365, in recompute
    apply_except_missing(self.compute_value, recs)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1338, in apply_except_missing
    func(records)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1387, in compute_value
    records._compute_field_value(self)
  File "/opt/odoo/auto/addons/mail/models/mail_thread.py", line 403, in _compute_field_value
    return super()._compute_field_value(field)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 4221, in _compute_field_value
    fields.determine(field.compute, self)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 97, in determine
    return needle(*args)
  File "/opt/odoo/auto/addons/crm/models/crm_lead.py", line 502, in _compute_prorated_revenue
    lead.prorated_revenue = round((lead.expected_revenue or 0.0) * (lead.probability or 0) / 100.0, 2)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1157, in __get__
    self.recompute(record)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1365, in recompute
    apply_except_missing(self.compute_value, recs)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1338, in apply_except_missing
    func(records)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1387, in compute_value
    records._compute_field_value(self)
  File "/opt/odoo/auto/addons/mail/models/mail_thread.py", line 403, in _compute_field_value
    return super()._compute_field_value(field)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 4221, in _compute_field_value
    fields.determine(field.compute, self)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 97, in determine
    return needle(*args)
  File "/opt/odoo/auto/addons/crm/models/crm_lead.py", line 491, in _compute_probabilities
    lead_probabilities = self._pls_get_naive_bayes_probabilities()
  File "/opt/odoo/auto/addons/crm/models/crm_lead.py", line 2079, in _pls_get_naive_bayes_probabilities
    leads_values_dict = self._pls_get_lead_pls_values(domain=domain)
  File "/opt/odoo/auto/addons/crm/models/crm_lead.py", line 2627, in _pls_get_lead_pls_values
    value = lead[field].id if isinstance(lead[field], models.BaseModel) else lead[field]
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 5897, in __getitem__
    return self._fields[key].__get__(self, type(self))
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1157, in __get__
    self.recompute(record)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1365, in recompute
    apply_except_missing(self.compute_value, recs)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1338, in apply_except_missing
    func(records)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 1387, in compute_value
    records._compute_field_value(self)
  File "/opt/odoo/auto/addons/mail/models/mail_thread.py", line 403, in _compute_field_value
    return super()._compute_field_value(field)
  File "/opt/odoo/custom/src/odoo/odoo/models.py", line 4221, in _compute_field_value
    fields.determine(field.compute, self)
  File "/opt/odoo/custom/src/odoo/odoo/fields.py", line 97, in determine
    return needle(*args)
  File "/opt/odoo/auto/addons/crm/models/crm_lead.py", line 477, in _compute_email_state
    if mail_validation.mail_validate(email):
  File "/opt/odoo/auto/addons/mail/tools/mail_validation.py", line 17, in mail_validate
    return bool(address.validate_address(email))
  File "/usr/local/lib/python3.10/site-packages/flanker/utils.py", line 64, in wrapper
    return_value = f(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/flanker/addresslib/address.py", line 312, in validate_address
    exchanger, mx_metrics = mail_exchanger_lookup(paddr.hostname, metrics=True)
  File "/usr/local/lib/python3.10/site-packages/flanker/utils.py", line 64, in wrapper
    return_value = f(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/flanker/addresslib/validate.py", line 146, in mail_exchanger_lookup
    in_cache, cache_value = lookup_exchanger_in_cache(domain)
  File "/usr/local/lib/python3.10/site-packages/flanker/addresslib/validate.py", line 188, in lookup_exchanger_in_cache
    lookup = _get_mx_cache()[domain]
  File "/usr/local/lib/python3.10/site-packages/flanker/addresslib/validate.py", line 238, in _get_mx_cache
    from flanker.addresslib.drivers.redis_driver import RedisCache
  File "/usr/local/lib/python3.10/site-packages/flanker/addresslib/drivers/redis_driver.py", line 6, in <module>
    class RedisCache(collections.MutableMapping):
AttributeError: module 'collections' has no attribute 'MutableMapping'
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 89, in load_demo
    load_data(cr, idref, mode, kind='demo', package=package)
  File "/opt/odoo/custom/src/odoo/odoo/modules/loading.py", line 71, in load_data
    tools.convert_file(cr, package.name, filename, idref, mode, noupdate, kind)
  File "/opt/odoo/custom/src/odoo/odoo/tools/convert.py", line 763, in convert_file
    convert_xml_import(cr, module, fp, idref, mode, noupdate)
  File "/opt/odoo/custom/src/odoo/odoo/tools/convert.py", line 829, in convert_xml_import
    obj.parse(doc.getroot())
  File "/opt/odoo/custom/src/odoo/odoo/tools/convert.py", line 749, in parse
    self._tag_root(de)
  File "/opt/odoo/custom/src/odoo/odoo/tools/convert.py", line 698, in _tag_root
    f(rec)
  File "/opt/odoo/custom/src/odoo/odoo/tools/convert.py", line 711, in _tag_root
    raise ParseError('while parsing %s:%s, somewhere inside\n%s' % (
odoo.tools.convert.ParseError: while parsing /opt/odoo/auto/addons/crm/data/crm_lead_demo.xml:339, somewhere inside
<function model="crm.lead" name="action_set_lost" eval="[[ref('crm_case_7'), ref('crm_case_9'), ref('crm_case_11'), ref('crm_case_12')]]" context="{'install_mode': True}"/>
```

</details>

@moduon MT-3948