### PR TITLE
[FIX] flanker new version dependencies

### DIFF
--- a/16.0.Dockerfile
+++ b/16.0.Dockerfile
@@ -123,6 +123,8 @@ RUN build_deps=" \
         click-odoo-contrib \
         debugpy \
         pydevd-odoo \
+        redis \
+        dnsq \
         git+https://github.com/mailgun/flanker.git@v0.9.15#egg=flanker \
         geoip2 \
         "git-aggregator<3.0.0" \

--- a/17.0.Dockerfile
+++ b/17.0.Dockerfile
@@ -123,6 +123,8 @@ RUN build_deps=" \
         click-odoo-contrib \
         debugpy \
         pydevd-odoo \
+        redis \
+        dnsq \
         git+https://github.com/mailgun/flanker.git@v0.9.15#egg=flanker \
         geoip2 \
         "git-aggregator<3.0.0" \


### PR DESCRIPTION
The newest flanker version includes 2 dependencies that are not automatically installed, so we need to explicitly add them.

@Tecnativa 