### PR TITLE
[FIX] if ~root/.ssh/ is prematurely created, we need to remove it, ensuring that AUTOAGGREGATE can read the ssh/config correctly

### DIFF
--- a/16.0.Dockerfile
+++ b/16.0.Dockerfile
@@ -224,7 +224,8 @@ ONBUILD COPY --chown=root:odoo $LOCAL_CUSTOM_DIR /opt/odoo/custom
 
 # https://docs.python.org/3/library/logging.html#levels
 ONBUILD ARG LOG_LEVEL=INFO
-ONBUILD RUN mkdir -p /opt/odoo/custom/ssh \
+ONBUILD RUN [[ -d ~root/.ssh ]] && rm -r ~root/.ssh; \
+            mkdir -p /opt/odoo/custom/ssh \
             && ln -s /opt/odoo/custom/ssh ~root/.ssh \
             && chmod -R u=rwX,go= /opt/odoo/custom/ssh \
             && sync

--- a/17.0.Dockerfile
+++ b/17.0.Dockerfile
@@ -224,7 +224,8 @@ ONBUILD COPY --chown=root:odoo $LOCAL_CUSTOM_DIR /opt/odoo/custom
 
 # https://docs.python.org/3/library/logging.html#levels
 ONBUILD ARG LOG_LEVEL=INFO
-ONBUILD RUN mkdir -p /opt/odoo/custom/ssh \
+ONBUILD RUN [[ -d ~root/.ssh ]] && rm -r ~root/.ssh; \
+            mkdir -p /opt/odoo/custom/ssh \
             && ln -s /opt/odoo/custom/ssh ~root/.ssh \
             && chmod -R u=rwX,go= /opt/odoo/custom/ssh \
             && sync

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -306,6 +306,8 @@ class ScaffoldingCase(unittest.TestCase):
             ("bash", "-xc", 'test "$(which geoipupdate)" != ""'),
             ("test", "!", "-e", "/usr/share/GeoIP/GeoLite2-City.mmdb"),
             ("bash", "-xc", "! geoipupdate"),
+            # Ensure /root/.ssh/ has not been mangled
+            ("bash", "-c", "[[ ! -d ~root/.ssh/ssh ]]"),
         )
         smallest_dir = join(SCAFFOLDINGS_DIR, "smallest")
         for sub_env in matrix():


### PR DESCRIPTION
I've run out of time to investigate further, but somehow a `/root/.ssh` directory is being prematurely created. This results in the symlink to /opt/odoo/custom/ssh being created as sub-directory (i.e. /root/.ssh/ssh rather than /root/.ssh).

I hope this change is suitable? 

I've tried to add a quick test to ensure that this is perhaps caught in future. I have not backported this to previous versions as it does not seem to be occurring there.

---

In the interim, if anyone wants a temporary workaround (created as `odoo/custom/build.d/099-fix-aggregate`):

```
#!/bin/bash
set -e

if [ -e ~root/.ssh/ssh/ ]; then
    log WARNING "Found nested SSH directory. Performing workaround for temporary fix for #582 / #585"

    unlink ~root/.ssh/ssh
    rm -rf ~root/.ssh/
    ln -sf /opt/odoo/custom/ssh ~root/.ssh

    sync
fi
```