### PR TITLE
Master fix uids GitHub

### DIFF
--- a/16.0.Dockerfile
+++ b/16.0.Dockerfile
@@ -5,6 +5,10 @@ EXPOSE 8069 8072
 ARG GEOIP_UPDATER_VERSION=4.3.0
 ARG WKHTMLTOPDF_VERSION=0.13.0
 ARG WKHTMLTOPDF_CHECKSUM='8feeb4d814263688d6e6fe28e03b541be5ca94f39c6e1ef8ff4c88dd8fb9443a'
+ARG LAST_SYSTEM_UID=499
+ARG LAST_SYSTEM_GID=499
+ARG FIRST_UID=500
+ARG FIRST_GID=500
 ENV DB_FILTER=.* \
     DEPTH_DEFAULT=1 \
     DEPTH_MERGE=100 \
@@ -33,7 +37,11 @@ ENV DB_FILTER=.* \
 
 # Other requirements and recommendations
 # See https://github.com/$ODOO_SOURCE/blob/$ODOO_VERSION/debian/control
-RUN apt-get -qq update \
+RUN echo "LAST_SYSTEM_UID=$LAST_SYSTEM_UID\nLAST_SYSTEM_GID=$LAST_SYSTEM_GID\nFIRST_UID=$FIRST_UID\nFIRST_GID=$FIRST_GID" >> /etc/adduser.conf \
+    && echo "SYS_UID_MAX   $LAST_SYSTEM_UID\nSYS_GID_MAX   $LAST_SYSTEM_GID" >> /etc/login.defs \
+    && sed -i -E "s/^UID_MIN\s+[0-9]+.*/UID_MIN   $FIRST_UID/;s/^GID_MIN\s+[0-9]+.*/GID_MIN   $FIRST_GID/" /etc/login.defs \
+    && useradd --system -u $LAST_SYSTEM_UID -s /usr/sbin/nologin -d / systemd-network \
+    && apt-get -qq update \
     && apt-get install -yqq --no-install-recommends \
         curl \
     && curl -SLo wkhtmltox.deb https://github.com/odoo/wkhtmltopdf/releases/download/nightly/wkhtmltox_${WKHTMLTOPDF_VERSION}-1.nightly.bookworm_amd64.deb \

--- a/17.0.Dockerfile
+++ b/17.0.Dockerfile
@@ -5,6 +5,10 @@ EXPOSE 8069 8072
 ARG GEOIP_UPDATER_VERSION=4.3.0
 ARG WKHTMLTOPDF_VERSION=0.13.0
 ARG WKHTMLTOPDF_CHECKSUM='8feeb4d814263688d6e6fe28e03b541be5ca94f39c6e1ef8ff4c88dd8fb9443a'
+ARG LAST_SYSTEM_UID=499
+ARG LAST_SYSTEM_GID=499
+ARG FIRST_UID=500
+ARG FIRST_GID=500
 ENV DB_FILTER=.* \
     DEPTH_DEFAULT=1 \
     DEPTH_MERGE=100 \
@@ -33,7 +37,11 @@ ENV DB_FILTER=.* \
 
 # Other requirements and recommendations
 # See https://github.com/$ODOO_SOURCE/blob/$ODOO_VERSION/debian/control
-RUN apt-get -qq update \
+RUN echo -e "LAST_SYSTEM_UID=$LAST_SYSTEM_UID\nLAST_SYSTEM_GID=$LAST_SYSTEM_GID\nFIRST_UID=$FIRST_UID\nFIRST_GID=$FIRST_GID" >> /etc/adduser.conf \
+    && echo "SYS_UID_MAX   $LAST_SYSTEM_UID\nSYS_GID_MAX   $LAST_SYSTEM_GID" >> /etc/login.defs \
+    && sed -i -E "s/^UID_MIN\s+[0-9]+.*/UID_MIN   $FIRST_UID/;s/^GID_MIN\s+[0-9]+.*/GID_MIN   $FIRST_GID/" /etc/login.defs \
+    && useradd --system -u $LAST_SYSTEM_UID -s /usr/sbin/nologin -d / systemd-network \
+    && apt-get -qq update \
     && apt-get install -yqq --no-install-recommends \
         curl \
     && curl -SLo wkhtmltox.deb https://github.com/odoo/wkhtmltopdf/releases/download/nightly/wkhtmltox_${WKHTMLTOPDF_VERSION}-1.nightly.bookworm_amd64.deb \

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -491,32 +491,35 @@ class ScaffoldingCase(unittest.TestCase):
 
     def test_modified_uids(self):
         """tests if we can build an image with a custom uid and gid of odoo"""
-        uids_dir = join(SCAFFOLDINGS_DIR, "uids_1001")
-        for sub_env in matrix():
-            self.compose_test(
-                uids_dir,
-                sub_env,
-                # verify that odoo user has the given ids
-                ("bash", "-xc", 'test "$(id -u)" == "1001"'),
-                ("bash", "-xc", 'test "$(id -g)" == "1002"'),
-                ("bash", "-xc", 'test "$(id -u -n)" == "odoo"'),
-                # all those directories need to belong to odoo (user or group odoo)
-                (
-                    "bash",
-                    "-xc",
-                    'test "$(stat -c \'%U:%G\' /var/lib/odoo)" == "odoo:odoo"',
-                ),
-                (
-                    "bash",
-                    "-xc",
-                    'test "$(stat -c \'%U:%G\' /opt/odoo/auto/addons)" == "root:odoo"',
-                ),
-                (
-                    "bash",
-                    "-xc",
-                    'test "$(stat -c \'%U:%G\' /opt/odoo/custom/src)" == "root:odoo"',
-                ),
-            )
+        for expected_uid, expected_gid, uids_dir in [
+            (1001, 1002, join(SCAFFOLDINGS_DIR, "uids_1001")),
+            (998, 998, join(SCAFFOLDINGS_DIR, "uids_998")),
+        ]:
+            for sub_env in matrix():
+                self.compose_test(
+                    uids_dir,
+                    sub_env,
+                    # verify that odoo user has the given ids
+                    ("bash", "-xc", 'test "$(id -u)" == "%s"' % expected_uid),
+                    ("bash", "-xc", 'test "$(id -g)" == "%s"' % expected_gid),
+                    ("bash", "-xc", 'test "$(id -u -n)" == "odoo"'),
+                    # all those directories need to belong to odoo (user or group odoo)
+                    (
+                        "bash",
+                        "-xc",
+                        'test "$(stat -c \'%U:%G\' /var/lib/odoo)" == "odoo:odoo"',
+                    ),
+                    (
+                        "bash",
+                        "-xc",
+                        'test "$(stat -c \'%U:%G\' /opt/odoo/auto/addons)" == "root:odoo"',
+                    ),
+                    (
+                        "bash",
+                        "-xc",
+                        'test "$(stat -c \'%U:%G\' /opt/odoo/custom/src)" == "root:odoo"',
+                    ),
+                )
 
     def test_uids_mac_os(self):
         """tests if we can build an image with a custom uid and gid of odoo"""

--- a/tests/scaffoldings/uids_998/Dockerfile
+++ b/tests/scaffoldings/uids_998/Dockerfile
@@ -1,0 +1,2 @@
+ARG ODOO_VERSION
+FROM tecnativa/doodba:${ODOO_VERSION}-onbuild

--- a/tests/scaffoldings/uids_998/docker-compose.yaml
+++ b/tests/scaffoldings/uids_998/docker-compose.yaml
@@ -1,0 +1,33 @@
+version: "2.1"
+services:
+  odoo:
+    build:
+      context: ./
+      args:
+        COMPILE: "false"
+        ODOO_VERSION: $ODOO_MINOR
+        PIP_INSTALL_ODOO: "false"
+        WITHOUT_DEMO: "false"
+        UID: 998
+        GID: 998
+
+    tty: true
+    depends_on:
+      - db
+    environment:
+      PYTHONOPTIMIZE: ""
+      UNACCENT: "false"
+    volumes:
+      - filestore:/var/lib/odoo:z
+
+  db:
+    image: postgres:${DB_VERSION}-alpine
+    environment:
+      POSTGRES_USER: odoo
+      POSTGRES_PASSWORD: odoopassword
+    volumes:
+      - db:/var/lib/postgresql/data:z
+
+volumes:
+  db:
+  filestore:


### PR DESCRIPTION
This is a fix for #586

With debian bookworm images it was not possible to run doodba with UID/GID 998 because these id's where used by systemd-network user.

This PR configures the system user boundary for debian to 499 / 500 (which is / was used by macOS for its users) and ensures that systemd-network user uses UID/GID=499

Previously UID 998 was only tested on our CI systems implicitly by the geoip tests (which were never activated on this projects CI), so now there is also a test that explicitly makes sure this use case (testing doodba with gitlab-runner) works.

Info @wt-io-it