### PR TITLE
[FIX] 16/17: Proper ~root/.ssh pre-removal

### DIFF
--- a/16.0.Dockerfile
+++ b/16.0.Dockerfile
@@ -230,7 +230,7 @@ ONBUILD COPY --chown=root:odoo $LOCAL_CUSTOM_DIR /opt/odoo/custom
 
 # https://docs.python.org/3/library/logging.html#levels
 ONBUILD ARG LOG_LEVEL=INFO
-ONBUILD RUN [[ -d ~root/.ssh ]] && rm -r ~root/.ssh; \
+ONBUILD RUN [ -d ~root/.ssh ] && rm -r ~root/.ssh; \
             mkdir -p /opt/odoo/custom/ssh \
             && ln -s /opt/odoo/custom/ssh ~root/.ssh \
             && chmod -R u=rwX,go= /opt/odoo/custom/ssh \

--- a/17.0.Dockerfile
+++ b/17.0.Dockerfile
@@ -230,7 +230,7 @@ ONBUILD COPY --chown=root:odoo $LOCAL_CUSTOM_DIR /opt/odoo/custom
 
 # https://docs.python.org/3/library/logging.html#levels
 ONBUILD ARG LOG_LEVEL=INFO
-ONBUILD RUN [[ -d ~root/.ssh ]] && rm -r ~root/.ssh; \
+ONBUILD RUN [ -d ~root/.ssh ] && rm -r ~root/.ssh; \
             mkdir -p /opt/odoo/custom/ssh \
             && ln -s /opt/odoo/custom/ssh ~root/.ssh \
             && chmod -R u=rwX,go= /opt/odoo/custom/ssh \


### PR DESCRIPTION
Hello, 

I found that the symlink to /opt/odoo/custom/ssh still being created as sub-directory (/root/.ssh/ssh) so I got an error when I tried to  build my Odoo image.

Docker uses "/bin/sh" as default shell and "[[ ]]" is a specific comparison construct of Bash.

I remove the brackets and now the symlinks to /opt/odoo/custom/ssh is being created succesfully.

Issue origin: https://github.com/Tecnativa/doodba/pull/585

@pedrobaeza 