### PR TITLE
[FIX] Fix docker image tags and ghcr.io auth credentials

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,8 +121,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.BOT_LOGIN }}
+          password: ${{ secrets.BOT_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
@@ -133,12 +133,14 @@ jobs:
             ${{ github.repository == 'tecnativa/doodba' && github.ref ==
             'refs/heads/master' }}
           tags: |
-            ${{ env.DOCKER_REPO }}:${{ matrix.odoo_version }}onbuild
+            ${{ env.DOCKER_REPO }}:${{ matrix.odoo_version }}
             ${{ env.DOCKER_REPO }}:${{ matrix.odoo_version }}-onbuild
             ${{ env.GHCR_HOST }}/${{ env.DOCKER_REPO }}${{ env.DOCKER_REPO_SUFFIX }}:${{ matrix.odoo_version }}
             ${{ env.GHCR_HOST }}/${{ env.DOCKER_REPO }}${{ env.DOCKER_REPO_SUFFIX }}:${{ matrix.odoo_version }}-onbuild
             ${{ matrix.odoo_version == env.LATEST_RELEASE && format('{0}:latest', env.DOCKER_REPO) || '' }}
+            ${{ matrix.odoo_version == env.LATEST_RELEASE && format('{0}:latest-onbuild', env.DOCKER_REPO) || '' }}
             ${{ matrix.odoo_version == env.LATEST_RELEASE && format('{0}/{1}{2}:latest', env.GHCR_HOST, env.DOCKER_REPO, env.DOCKER_REPO_SUFFIX) || '' }}
+            ${{ matrix.odoo_version == env.LATEST_RELEASE && format('{0}/{1}{2}:latest-onbuild', env.GHCR_HOST, env.DOCKER_REPO, env.DOCKER_REPO_SUFFIX) || '' }}
           build-args: |
             VCS_REF=${{ github.sha }}
             BUILD_DATE=${{ env.BUILD_DATE }}


### PR DESCRIPTION
Hi @pedrobaeza small fix incoming:

1. The tags which are pushed should now be as before - {ODOO_VERSION}, {ODOO_VERSION}-onbuild and latest, latest-onbuild (where applicable)
2. The push to ghcr.io failed with the default credentials, I have switched them to the old ones hoping they will pass this time. If this also fails maybe you need to look into the permissions of the default github.repository_owner / secrets.GITHUB_TOKEN since authentication was sucessful.

Also after this works you would need to delete the extra {ODOO_VERSION}onbuild (with the missing -)

Fingers crossed :crossed_fingers: 