### PR TITLE
Ignore manifest check for l10n_generic_coa in 17.0 and above

### DIFF
--- a/lib/doodbalib/__init__.py
+++ b/lib/doodbalib/__init__.py
@@ -129,7 +129,6 @@ def addons_config(filtered=True, strict=False):
                 skip_coa_17 = False
                 try:
                     odoo_version_float = float(ODOO_VERSION)
-                    skip_coa_17 = odoo_version_float >= 17 and addon_name == 'l10n_generic_coa'
                     skip_coa_17 = (
                         odoo_version_float >= 17 and addon_name == "l10n_generic_coa"
                     )

--- a/lib/doodbalib/__init__.py
+++ b/lib/doodbalib/__init__.py
@@ -130,6 +130,9 @@ def addons_config(filtered=True, strict=False):
                 try:
                     odoo_version_float = float(ODOO_VERSION)
                     skip_coa_17 = odoo_version_float >= 17 and addon_name == 'l10n_generic_coa'
+                    skip_coa_17 = (
+                        odoo_version_float >= 17 and addon_name == "l10n_generic_coa"
+                    )
                 except Exception:
                     pass
                 manifests = (os.path.join(addon, m) for m in MANIFESTS)

--- a/lib/doodbalib/__init__.py
+++ b/lib/doodbalib/__init__.py
@@ -125,17 +125,23 @@ def addons_config(filtered=True, strict=False):
             for addon in found:
                 if not os.path.isdir(addon):
                     continue
+                addon_name = os.path.basename(addon)
+                skip_coa_17 = False
+                try:
+                    odoo_version_float = float(ODOO_VERSION)
+                    skip_coa_17 = odoo_version_float >= 17 and addon_name == 'l10n_generic_coa'
+                except Exception:
+                    pass
                 manifests = (os.path.join(addon, m) for m in MANIFESTS)
-                if not any(os.path.isfile(m) for m in manifests):
+                if not any(os.path.isfile(m) for m in manifests) and not skip_coa_17:
                     missing_manifest.add(addon)
                     logger.debug(
                         "Skipping '%s' as it is not a valid Odoo " "module", addon
                     )
                     continue
                 logger.debug("Registering addon %s", addon)
-                addon = os.path.basename(addon)
-                config.setdefault(addon, set())
-                config[addon].add(repo)
+                config.setdefault(addon_name, set())
+                config[addon_name].add(repo)
     # Fail now if running in strict mode
     if strict:
         error = []


### PR DESCRIPTION
Since Odoo 17.0 they removed the module `l10n_generic_coa`, but they kept its directory and with only the __init__.py file.

This causes manifest check to fail if `strict` was `True`.

This commit causes `addons_config` to ignore this module for 17.0 and above.