### PR TITLE
[FIX] 20-postgres-wait: avoid assuming you have permission to list database

### DIFF
--- a/entrypoint.d/20-postgres-wait
+++ b/entrypoint.d/20-postgres-wait
@@ -6,6 +6,16 @@ fi
 
 log INFO Waiting until postgres is listening at $PGHOST...
 while true; do
-    psql --list > /dev/null 2>&1 && break
+    # If your postgres connection has minimal permissions, you should
+    # have at least an empty PGDATABASE and rights on this
+    # databases. The following will then succeed:
+    [ -n "$PGDATABASE" ] && echo "SELECT 1;" | psql "$PGDATABASE" > /dev/null 2>&1 && break
+
+    # if previous check failed (if PGDATABASE is set, but not yet
+    # created), you are in a more common scenario where odoo is
+    # expected to manage databases, and it should have the permissions
+    # to create it and will attempt to do it. In that case, you'll
+    # probably also have the permissions to list the databases.
+    psql -l > /dev/null 2>&1 && break
     sleep 1
 done


### PR DESCRIPTION
When having to connect to external database access, you often only have access to a specific user/password on a single database, with no rights to access 'postgres' database, and thus no rights to list databases. (Using: `REVOKE ALL ON DATABASE postgres FROM PUBLIC;`, which is a common security practice). Notice that OVH for instance seems to do that on their [mutualized postgres offers](https://www.ovhcloud.com/en/public-cloud/postgresql/)

If odoo itself has known [issues](https://github.com/odoo/odoo/issues/12850) into supporting this scenario, it is easily patchable (cf: https://github.com/odoo/odoo/issues/12850#issuecomment-2222886101 ).

If you can't list databases, you probably have the `$PGDATABASE` set, so I triggered the change on the existence of this variable. Although, I'm not sure how other people use this image, so I'd be happy to have your feedback on the pertinence of this patch in your perspective.

Also, it should probably be a good idea to set `$DB_FILTER` to be empty (to override the default of the current image which is `.*`, which by defaults, prevents odoo to actually use `db_name` option, cf: https://github.com/odoo/odoo/blob/master/odoo/service/db.py#L413-L418 ). 

With my patch, the tecnativa image won't stop forever asking for something it can't have in the aforementioned scenario.

Many thanks for your work on this image.