### PR TITLE
[FIX] Use the apt-archive for postgres in versions using buster

### DIFF
--- a/13.0.Dockerfile
+++ b/13.0.Dockerfile
@@ -56,7 +56,7 @@ RUN apt-get -qq update \
         telnet \
         vim \
         zlibc \
-    && echo 'deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main' >> /etc/apt/sources.list.d/postgresql.list \
+    && echo 'deb https://apt-archive.postgresql.org/pub/repos/apt buster-pgdg main' >> /etc/apt/sources.list.d/postgresql.list \
     && curl -SL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
     && apt-get update \
     && apt-get install -yqq --no-install-recommends \

--- a/14.0.Dockerfile
+++ b/14.0.Dockerfile
@@ -72,7 +72,7 @@ RUN apt-get -qq update \
         telnet \
         vim \
         zlibc \
-    && echo 'deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main' >> /etc/apt/sources.list.d/postgresql.list \
+    && echo 'deb https://apt-archive.postgresql.org/pub/repos/apt buster-pgdg main' >> /etc/apt/sources.list.d/postgresql.list \
     && curl -SL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
     && apt-get update \
     && curl --silent -L --output geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb https://github.com/maxmind/geoipupdate/releases/download/v${GEOIP_UPDATER_VERSION}/geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb \


### PR DESCRIPTION
Just like when stretch was archived https://github.com/Tecnativa/doodba/pull/528. I haven't found an official announcement but the error speaks for itself:
```
#4 33.00 doodba INFO: Executing: ['apt-get', 'update']
#4 33.05 Get:1 http://deb.debian.org/debian buster InRelease [122 kB]
#4 33.05 Get:2 http://security.debian.org/debian-security buster/updates InRelease [34.8 kB]
#4 33.07 Get:3 http://deb.debian.org/debian buster-updates InRelease [56.6 kB]
#4 33.10 Ign:4 http://apt.postgresql.org/pub/repos/apt buster-pgdg InRelease
#4 33.13 Err:5 http://apt.postgresql.org/pub/repos/apt buster-pgdg Release
#4 33.13   404  Not Found [IP: 87.238.57.227 80]
#4 33.19 Get:6 http://security.debian.org/debian-security buster/updates/main amd64 Packages [610 kB]
#4 33.32 Get:7 http://deb.debian.org/debian buster/main amd64 Packages [7909 kB]
#4 33.45 Get:8 http://deb.debian.org/debian buster-updates/main amd64 Packages [8788 B]
#4 34.42 Reading package lists...
#4 34.99 E: The repository 'http://apt.postgresql.org/pub/repos/apt buster-pgdg Release' does not have a Release file.
```
Also, `buster-pgdg` can be found in https://apt-archive.postgresql.org/pub/repos/apt/dists/index.html but not in https://apt.postgresql.org/pub/repos/apt/dists/.