### PR TITLE
[FIX] Mark /tmp/fake-odoo as safe

### DIFF
--- a/13.0.Dockerfile
+++ b/13.0.Dockerfile
@@ -56,7 +56,7 @@ RUN apt-get -qq update \
         telnet \
         vim \
         zlibc \
-    && echo 'deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main' >> /etc/apt/sources.list.d/postgresql.list \
+    && echo 'deb https://apt-archive.postgresql.org/pub/repos/apt buster-pgdg main' >> /etc/apt/sources.list.d/postgresql.list \
     && curl -SL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
     && apt-get update \
     && apt-get install -yqq --no-install-recommends \

--- a/14.0.Dockerfile
+++ b/14.0.Dockerfile
@@ -72,7 +72,7 @@ RUN apt-get -qq update \
         telnet \
         vim \
         zlibc \
-    && echo 'deb http://apt.postgresql.org/pub/repos/apt/ buster-pgdg main' >> /etc/apt/sources.list.d/postgresql.list \
+    && echo 'deb https://apt-archive.postgresql.org/pub/repos/apt buster-pgdg main' >> /etc/apt/sources.list.d/postgresql.list \
     && curl -SL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
     && apt-get update \
     && curl --silent -L --output geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb https://github.com/maxmind/geoipupdate/releases/download/v${GEOIP_UPDATER_VERSION}/geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb \

--- a/tests/scaffoldings/repo_merge/custom/build.d/099-create-fake-odoo
+++ b/tests/scaffoldings/repo_merge/custom/build.d/099-create-fake-odoo
@@ -4,6 +4,7 @@ mkdir /tmp/fake-odoo
 cd /tmp/fake-odoo
 
 git init
+git config --system --add safe.directory /tmp/fake-odoo/.git
 touch odoo-bin
 git add odoo-bin
 git commit -m odoo-bin


### PR DESCRIPTION
Fixing issue mentioned here https://github.com/Tecnativa/doodba/pull/623#issuecomment-2378896167