### PR TITLE
[IMP] 16,17,18: use gevent 22.10.2

### DIFF
--- a/16.0.Dockerfile
+++ b/16.0.Dockerfile
@@ -142,12 +142,8 @@ RUN build_deps=" \
     && apt-get update \
     && apt-get install -yqq --no-install-recommends $build_deps \
     && curl -o requirements.txt https://raw.githubusercontent.com/$ODOO_SOURCE/$ODOO_VERSION/requirements.txt \
-    &&  \
-        if [ "$TARGETARCH" = "arm64" ]; then \
-        echo "Upgrading odoo requirements.txt with gevent==21.12.0 and greenlet==1.1.0 (minimum version compatible with arm64)" && \
-        sed -i 's/gevent==[0-9\.]*/gevent==21.12.0/' requirements.txt && \
-        sed -i 's/greenlet==[0-9\.]*/greenlet==1.1.0/' requirements.txt; \
-    fi \
+    # disable gevent version recommendation from odoo and use 22.10.2 used in debian bookworm as python3-gevent
+    && sed -i -E "s/(gevent==)21\.8\.0( ; sys_platform != 'win32' and python_version > '3.9' and python_version <= '3.10')/\122.10.2\2/;s/(greenlet==)1.1.2( ; sys_platform != 'win32' and python_version  > '3.9' and python_version <= '3.10')/\12.0.2\2/" requirements.txt \
     && pip install -r requirements.txt \
         'websocket-client~=0.56' \
         astor \

--- a/17.0.Dockerfile
+++ b/17.0.Dockerfile
@@ -141,11 +141,8 @@ RUN build_deps=" \
     && apt-get update \
     && apt-get install -yqq --no-install-recommends $build_deps \
     && curl -o requirements.txt https://raw.githubusercontent.com/$ODOO_SOURCE/$ODOO_VERSION/requirements.txt \
-    &&  \
-        if [ "$TARGETARCH" = "arm64" ]; then \
-        echo "Upgrading odoo requirements.txt with gevent==21.12.0 (minimum version compatible with arm64)" && \
-        sed -i 's/gevent==[0-9\.]*/gevent==21.12.0/' requirements.txt; \
-    fi \
+    # disable gevent version recommendation from odoo and use 22.10.2 used in debian bookworm as python3-gevent
+    && sed -i -E "s/(gevent==)21\.8\.0( ; sys_platform != 'win32' and python_version == '3.10')/\122.10.2\2/;s/(greenlet==)1.1.2( ; sys_platform != 'win32' and python_version == '3.10')/\12.0.2\2/" requirements.txt \
     && pip install -r requirements.txt \
         'websocket-client~=0.56' \
         astor \

--- a/18.0.Dockerfile
+++ b/18.0.Dockerfile
@@ -141,11 +141,8 @@ RUN build_deps=" \
     && apt-get update \
     && apt-get install -yqq --no-install-recommends $build_deps \
     && curl -o requirements.txt https://raw.githubusercontent.com/$ODOO_SOURCE/$ODOO_VERSION/requirements.txt \
-    &&  \
-        if [ "$TARGETARCH" = "arm64" ]; then \
-        echo "Upgrading odoo requirements.txt with gevent==21.12.0 (minimum version compatible with arm64)" && \
-        sed -i 's/gevent==[0-9\.]*/gevent==21.12.0/' requirements.txt; \
-    fi \
+    # disable gevent version recommendation from odoo and use 22.10.2 used in debian bookworm as python3-gevent
+    && sed -i -E "s/(gevent==)21\.8\.0( ; sys_platform != 'win32' and python_version == '3.10')/\122.10.2\2/;s/(greenlet==)1.1.2( ; sys_platform != 'win32' and python_version == '3.10')/\12.0.2\2/" requirements.txt \
     && pip install -r requirements.txt \
         'websocket-client~=0.56' \
         astor \


### PR DESCRIPTION
pip install gevent==21.8.0 fails with exception when installing with pip in ubuntu/debian. gevent 22.10.2 then also requires greenlet 2.0.2

`docker run --rm -it python:3.10-bookworm bash -c 'pip install gevent==21.8.0'` fails with
```
Collecting gevent==21.8.0
  Downloading gevent-21.8.0.tar.gz (6.2 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 6.2/6.2 MB 46.4 MB/s eta 0:00:00
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [45 lines of output]
      Compiling src/gevent/resolver/cares.pyx because it changed.
      [1/1] Cythonizing src/gevent/resolver/cares.pyx
      performance hint: src/gevent/libev/corecext.pyx:1325:0: Exception check on '_syserr_cb' will always require the GIL to be acquired.
      Possible solutions:
          1. Declare '_syserr_cb' as 'noexcept' if you control the definition and you're sure you don't want the function to raise exceptions.
          2. Use an 'int' return type on '_syserr_cb' to allow an error code to be returned.
      
      Error compiling Cython file:
      ------------------------------------------------------------
      ...
      cdef tuple integer_types
      
      if sys.version_info[0] >= 3:
          integer_types = int,
      else:
          integer_types = (int, long)
                                ^
      ------------------------------------------------------------
      
      src/gevent/libev/corecext.pyx:60:26: undeclared name not builtin: long
      Compiling src/gevent/libev/corecext.pyx because it changed.
      [1/1] Cythonizing src/gevent/libev/corecext.pyx
      Traceback (most recent call last):
        File "/usr/local/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/usr/local/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/usr/local/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/tmp/pip-build-env-f3cscebe/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 333, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
        File "/tmp/pip-build-env-f3cscebe/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 303, in _get_build_requires
          self.run_setup()
        File "/tmp/pip-build-env-f3cscebe/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 521, in run_setup
          super().run_setup(setup_script=setup_script)
        File "/tmp/pip-build-env-f3cscebe/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 319, in run_setup
          exec(code, locals())
        File "<string>", line 50, in <module>
        File "/tmp/pip-install-a8g2mn2g/gevent_fb4a8bed0ca9477996b7a7b73cc4c2e5/_setuputils.py", line 237, in cythonize1
          new_ext = cythonize(
        File "/tmp/pip-build-env-f3cscebe/overlay/lib/python3.10/site-packages/Cython/Build/Dependencies.py", line 1109, in cythonize
          cythonize_one(*args)
        File "/tmp/pip-build-env-f3cscebe/overlay/lib/python3.10/site-packages/Cython/Build/Dependencies.py", line 1256, in cythonize_one
          raise CompileError(None, pyx_file)
      Cython.Compiler.Errors.CompileError: src/gevent/libev/corecext.pyx
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.

[notice] A new release of pip is available: 23.0.1 -> 24.3.1
[notice] To update, run: pip install --upgrade pip
```

`docker run --rm -it python:3.10-bookworm bash -c 'pip install gevent==22.10.2'` succeeds and is the same version suggested by odoo for python3.11 so it should most likely also work
```
Collecting gevent==22.10.2
  Downloading gevent-22.10.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (6.4 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 6.4/6.4 MB 45.8 MB/s eta 0:00:00
Collecting greenlet>=2.0.0
  Downloading greenlet-3.1.1-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl (599 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 599.5/599.5 kB 55.9 MB/s eta 0:00:00
Requirement already satisfied: setuptools in /usr/local/lib/python3.10/site-packages (from gevent==22.10.2) (65.5.1)
Collecting zope.interface
  Downloading zope.interface-7.1.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (254 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 254.2/254.2 kB 30.9 MB/s eta 0:00:00
Collecting zope.event
  Downloading zope.event-5.0-py3-none-any.whl (6.8 kB)
Installing collected packages: zope.interface, zope.event, greenlet, gevent
Successfully installed gevent-22.10.2 greenlet-3.1.1 zope.event-5.0 zope.interface-7.1.1
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv

[notice] A new release of pip is available: 23.0.1 -> 24.3.1
[notice] To update, run: pip install --upgrade pip
```

@PCatinean could you also have a look if this looks ok for arm64?

info @wt-io-it