### PR TITLE
[FIX] 15.0: purge apt data in the same layer as install

### DIFF
--- a/15.0.Dockerfile
+++ b/15.0.Dockerfile
@@ -166,8 +166,8 @@ RUN build_deps=" \
     && (python3 -m compileall -q /usr/local/lib/python3.8/ || true) \
     # generate flanker cached tables during install when /usr/local/lib/ is still intended to be written to
     # https://github.com/Tecnativa/doodba/issues/486
-    && python3 -c 'from flanker.addresslib import address' >/dev/null 2>&1
-RUN apt-get purge -yqq $build_deps \
+    && python3 -c 'from flanker.addresslib import address' >/dev/null 2>&1 \
+    && apt-get purge -yqq $build_deps \
     && apt-get autopurge -yqq \
     && rm -Rf /var/lib/apt/lists/* /tmp/*
 

--- a/15.0.Dockerfile
+++ b/15.0.Dockerfile
@@ -57,7 +57,7 @@ RUN apt-get -qq update \
     && echo "Expected wkhtmltox checksum: ${WKHTMLTOPDF_CHECKSUM}" \
     && echo "Computed wkhtmltox checksum: $(sha256sum wkhtmltox.deb | awk '{ print $1 }')" \
     && echo "${WKHTMLTOPDF_CHECKSUM} wkhtmltox.deb" | sha256sum -c - \
-    && dpkg -i wkhtmltox.deb || apt-get -y install -f \
+    && (dpkg -i wkhtmltox.deb || apt-get -y install -f) \
     && apt-get install -yqq --no-install-recommends \
         chromium \
         ffmpeg \


### PR DESCRIPTION
```Dockerfile
RUN apt-get purge -yqq $build_deps \
    && apt-get autopurge -yqq \
    && rm -Rf /var/lib/apt/lists/* /tmp/*
```
Does not make sense from docker layer perspective if it's not run in the same layer as the install. It also does not make sense from a shell perspective if `$build_deps` is not set for `apt-get purge -yqq $build_deps`.

With https://github.com/Tecnativa/doodba/commit/21b8bde780564d92b150e72a22b2ada90c95d65e#diff-32129c0c5001d86cef22a1cecd12993dd630e851a67b5d286cef38b2399ac96bR170-R173 it seems build_deps are no longer removed after components are built and installed.

If this behaviour is required in TT54577 (it's always hard to assume what the issues are you are experiencing if the description is pretty empty: https://github.com/Tecnativa/doodba/pull/644) do not merge this and if possible/allowed tell us what the issue was.

For us the change broke the efficiency test for a image cleanup script as image size for our cleaned up image. It goes from 1.1G to 2.2G with the previous PR (propably because the build_deps do no longer get removed in 15.0).

Info @wt-io-it