### PR TITLE
[IMP] Set gevent==21.12.0 & greenlet==1.1.0 for all architectures to ensure consistency

### DIFF
--- a/14.0.Dockerfile
+++ b/14.0.Dockerfile
@@ -140,12 +140,8 @@ RUN build_deps=" \
     && apt-get update \
     && apt-get install -yqq --no-install-recommends $build_deps \
     && curl -o requirements.txt https://raw.githubusercontent.com/$ODOO_SOURCE/$ODOO_VERSION/requirements.txt \
-    &&  \
-        if [ "$TARGETARCH" = "arm64" ]; then \
-        echo "Upgrading odoo requirements.txt with gevent==21.12.0 and greenlet==1.1.0 (minimum versions compatible with arm64)" && \
-        sed -i 's/gevent==[0-9\.]*/gevent==21.12.0/' requirements.txt && \
-        sed -i 's/greenlet==[0-9\.]*/greenlet==1.1.0/' requirements.txt; \
-    fi \
+    && echo "Setting gevent and greenlet versions to 21.12.0 and 1.1.0 (compatible with Debian Buster)" \
+    && sed -i -E "s/(gevent==)[0-9\.]+/\121.12.0/; s/(greenlet==)[0-9\.]+/\11.1.0/" requirements.txt \
     && pip install -r requirements.txt \
         'websocket-client~=0.56' \
         astor \

--- a/15.0.Dockerfile
+++ b/15.0.Dockerfile
@@ -138,12 +138,8 @@ RUN build_deps=" \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -yqq --no-install-recommends $build_deps \
     && curl -o requirements.txt https://raw.githubusercontent.com/$ODOO_SOURCE/$ODOO_VERSION/requirements.txt \
-    &&  \
-        if [ "$TARGETARCH" = "arm64" ]; then \
-        echo "Upgrading odoo requirements.txt with gevent==21.12.0 and greenlet==1.1.0 (minimum versions compatible with arm64)" && \
-        sed -i 's/gevent==[0-9\.]*/gevent==21.12.0/' requirements.txt && \
-        sed -i 's/greenlet==[0-9\.]*/greenlet==1.1.0/' requirements.txt; \
-    fi \
+    && echo "Setting gevent and greenlet versions to 21.12.0 and 1.1.0 (compatible with Debian Bullseye)" \
+    && sed -i -E "s/(gevent==)[0-9\.]+/\121.12.0/; s/(greenlet==)[0-9\.]+/\11.1.0/" requirements.txt \
     && pip install -r requirements.txt \
         'websocket-client~=0.56' \
         astor \


### PR DESCRIPTION
Fixed incompatibility error between gevent and greenlet:
`ValueError: greenlet.greenlet size changed, may indicate binary incompatibility. Expected 152 from C header, got 40 from PyObject`
To ensure consistency and compatibility across architectures, we now set `gevent==21.12.0` and `greenlet==1.1.0` for both amd64 and arm64. This prevents binary mismatch issues and improves container stability.
CC @Tecnativa TT55390