### PR TITLE
[FIX] build: need to upgrade setuptools

### DIFF
--- a/16.0.Dockerfile
+++ b/16.0.Dockerfile
@@ -144,6 +144,8 @@ RUN build_deps=" \
     && curl -o requirements.txt https://raw.githubusercontent.com/$ODOO_SOURCE/$ODOO_VERSION/requirements.txt \
     # disable gevent version recommendation from odoo and use 22.10.2 used in debian bookworm as python3-gevent
     && sed -i -E "s/(gevent==)21\.8\.0( ; sys_platform != 'win32' and python_version > '3.9' and python_version <= '3.10')/\122.10.2\2/;s/(greenlet==)1.1.2( ; sys_platform != 'win32' and python_version  > '3.9' and python_version <= '3.10')/\12.0.2\2/" requirements.txt \
+    # need to upgrade setuptools, since the fixes for CVE-2024-6345 rolled out in base images we get errors "error: invalid command 'bdist_wheel'"
+    && pip install --upgrade setuptools \
     && pip install -r requirements.txt \
         'websocket-client~=0.56' \
         astor \

--- a/17.0.Dockerfile
+++ b/17.0.Dockerfile
@@ -143,6 +143,8 @@ RUN build_deps=" \
     && curl -o requirements.txt https://raw.githubusercontent.com/$ODOO_SOURCE/$ODOO_VERSION/requirements.txt \
     # disable gevent version recommendation from odoo and use 22.10.2 used in debian bookworm as python3-gevent
     && sed -i -E "s/(gevent==)21\.8\.0( ; sys_platform != 'win32' and python_version == '3.10')/\122.10.2\2/;s/(greenlet==)1.1.2( ; sys_platform != 'win32' and python_version == '3.10')/\12.0.2\2/" requirements.txt \
+    # need to upgrade setuptools, since the fixes for CVE-2024-6345 rolled out in base images we get errors "error: invalid command 'bdist_wheel'"
+    && pip install --upgrade setuptools \
     && pip install -r requirements.txt \
         'websocket-client~=0.56' \
         astor \

--- a/18.0.Dockerfile
+++ b/18.0.Dockerfile
@@ -143,6 +143,8 @@ RUN build_deps=" \
     && curl -o requirements.txt https://raw.githubusercontent.com/$ODOO_SOURCE/$ODOO_VERSION/requirements.txt \
     # disable gevent version recommendation from odoo and use 22.10.2 used in debian bookworm as python3-gevent
     && sed -i -E "s/(gevent==)21\.8\.0( ; sys_platform != 'win32' and python_version == '3.10')/\122.10.2\2/;s/(greenlet==)1.1.2( ; sys_platform != 'win32' and python_version == '3.10')/\12.0.2\2/" requirements.txt \
+    # need to upgrade setuptools, since the fixes for CVE-2024-6345 rolled out in base images we get errors "error: invalid command 'bdist_wheel'"
+    && pip install --upgrade setuptools \
     && pip install -r requirements.txt \
         'websocket-client~=0.56' \
         astor \


### PR DESCRIPTION
I noticed yesterday that dockerhub started rolling out updated images for alpine / python, when one of our builds broke when using `python:3.11-alpine` `pip install .` gave an error `error: invalid command 'bdist_wheel'`. Upgrading setuptools fixes this.

I assume this is with regards to CVE-2024-6345 but cannot find out anything more why that may break pip install. The installed (numerical) version of setuptools stayed the same but maybe there is a strange patch in there.

Today our doodba (and docker-whitelist) builds broke in the morning for 16.0, 17.0 and 18.0:
```
...
#25 53.04   Building wheel for qrcode (setup.py): started
#25 53.22   Building wheel for qrcode (setup.py): finished with status 'error'
#25 53.23   error: subprocess-exited-with-error
#25 53.23   
#25 53.23   × python setup.py bdist_wheel did not run successfully.
#25 53.23   │ exit code: 1
#25 53.23   ╰─> [6 lines of output]
#25 53.23       usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
#25 53.23          or: setup.py --help [cmd1 cmd2 ...]
#25 53.23          or: setup.py --help-commands
#25 53.23          or: setup.py cmd --help
#25 53.23       
#25 53.23       error: invalid command 'bdist_wheel'
#25 53.23       [end of output]
#25 53.23   
#25 53.23   note: This error originates from a subprocess, and is likely not a problem with pip.
#25 53.23   ERROR: Failed building wheel for qrcode
#25 53.23   Running setup.py clean for qrcode
#25 53.42   Building wheel for rjsmin (setup.py): started
#25 53.60   Building wheel for rjsmin (setup.py): finished with status 'error'
#25 53.60   error: subprocess-exited-with-error
#25 53.60   
#25 53.60   × python setup.py bdist_wheel did not run successfully.
#25 53.60   │ exit code: 1
#25 53.60   ╰─> [6 lines of output]
#25 53.60       usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
#25 53.60          or: setup.py --help [cmd1 cmd2 ...]
#25 53.60          or: setup.py --help-commands
#25 53.60          or: setup.py cmd --help
#25 53.60       
#25 53.60       error: invalid command 'bdist_wheel'
#25 53.60       [end of output]
#25 53.60   
#25 53.60   note: This error originates from a subprocess, and is likely not a problem with pip.
#25 53.60   ERROR: Failed building wheel for rjsmin
#25 53.60   Running setup.py clean for rjsmin
#25 53.77   Building wheel for vobject (setup.py): started
#25 53.93   Building wheel for vobject (setup.py): finished with status 'error'
#25 53.93   error: subprocess-exited-with-error
#25 53.93   
#25 53.93   × python setup.py bdist_wheel did not run successfully.
#25 53.93   │ exit code: 1
#25 53.93   ╰─> [8 lines of output]
#25 53.93       /usr/local/lib/python3.10/site-packages/setuptools/_distutils/dist.py:264: UserWarning: Unknown distribution option: 'bugtrack_url'
#25 53.93         warnings.warn(msg)
#25 53.93       usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
#25 53.93          or: setup.py --help [cmd1 cmd2 ...]
#25 53.93          or: setup.py --help-commands
#25 53.93          or: setup.py cmd --help
#25 53.93       
#25 53.93       error: invalid command 'bdist_wheel'
#25 53.93       [end of output]
#25 53.93   
#25 53.93   note: This error originates from a subprocess, and is likely not a problem with pip.
#25 53.93   ERROR: Failed building wheel for vobject
#25 53.93   Running setup.py clean for vobject
#25 54.09   Building wheel for flanker (setup.py): started
#25 54.27   Building wheel for flanker (setup.py): finished with status 'error'
#25 54.27   error: subprocess-exited-with-error
#25 54.27   
#25 54.27   × python setup.py bdist_wheel did not run successfully.
#25 54.27   │ exit code: 1
#25 54.27   ╰─> [6 lines of output]
#25 54.27       usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
#25 54.27          or: setup.py --help [cmd1 cmd2 ...]
#25 54.27          or: setup.py --help-commands
#25 54.27          or: setup.py cmd --help
#25 54.27       
#25 54.27       error: invalid command 'bdist_wheel'
#25 54.27       [end of output]
#25 54.27   
#25 54.27   note: This error originates from a subprocess, and is likely not a problem with pip.
#25 54.27   ERROR: Failed building wheel for flanker
#25 54.27   Running setup.py clean for flanker
#25 54.45   Building wheel for inotify (setup.py): started
#25 54.62   Building wheel for inotify (setup.py): finished with status 'error'
#25 54.62   error: subprocess-exited-with-error
#25 54.62   
#25 54.62   × python setup.py bdist_wheel did not run successfully.
#25 54.62   │ exit code: 1
#25 54.62   ╰─> [6 lines of output]
#25 54.62       usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
#25 54.62          or: setup.py --help [cmd1 cmd2 ...]
#25 54.62          or: setup.py --help-commands
#25 54.62          or: setup.py cmd --help
#25 54.62       
#25 54.62       error: invalid command 'bdist_wheel'
#25 54.62       [end of output]
#25 54.62   
#25 54.62   note: This error originates from a subprocess, and is likely not a problem with pip.
#25 54.62   ERROR: Failed building wheel for inotify
#25 54.62   Running setup.py clean for inotify
#25 54.79   Building wheel for wdb (setup.py): started
#25 54.95   Building wheel for wdb (setup.py): finished with status 'error'
#25 54.96   error: subprocess-exited-with-error
#25 54.96   
#25 54.96   × python setup.py bdist_wheel did not run successfully.
#25 54.96   │ exit code: 1
#25 54.96   ╰─> [6 lines of output]
#25 54.96       usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
#25 54.96          or: setup.py --help [cmd1 cmd2 ...]
#25 54.96          or: setup.py --help-commands
#25 54.96          or: setup.py cmd --help
#25 54.96       
#25 54.96       error: invalid command 'bdist_wheel'
#25 54.96       [end of output]
#25 54.96   
#25 54.96   note: This error originates from a subprocess, and is likely not a problem with pip.
#25 54.96   ERROR: Failed building wheel for wdb
#25 54.96   Running setup.py clean for wdb
#25 55.12   Building wheel for unicodecsv (setup.py): started
#25 55.31   Building wheel for unicodecsv (setup.py): finished with status 'error'
#25 55.31   error: subprocess-exited-with-error
#25 55.31   
#25 55.31   × python setup.py bdist_wheel did not run successfully.
#25 55.31   │ exit code: 1
#25 55.31   ╰─> [6 lines of output]
#25 55.31       usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
#25 55.31          or: setup.py --help [cmd1 cmd2 ...]
#25 55.31          or: setup.py --help-commands
#25 55.31          or: setup.py cmd --help
#25 55.31       
#25 55.31       error: invalid command 'bdist_wheel'
#25 55.31       [end of output]
#25 55.31   
#25 55.31   note: This error originates from a subprocess, and is likely not a problem with pip.
#25 55.31   ERROR: Failed building wheel for unicodecsv
#25 55.31   Running setup.py clean for unicodecsv
#25 55.50   Building wheel for dnsq (setup.py): started
#25 55.68   Building wheel for dnsq (setup.py): finished with status 'error'
#25 55.68   error: subprocess-exited-with-error
#25 55.68   
#25 55.68   × python setup.py bdist_wheel did not run successfully.
#25 55.68   │ exit code: 1
#25 55.68   ╰─> [6 lines of output]
#25 55.68       usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
#25 55.68          or: setup.py --help [cmd1 cmd2 ...]
#25 55.68          or: setup.py --help-commands
#25 55.68          or: setup.py cmd --help
#25 55.68       
#25 55.68       error: invalid command 'bdist_wheel'
#25 55.68       [end of output]
#25 55.68   
#25 55.68   note: This error originates from a subprocess, and is likely not a problem with pip.
#25 55.68   ERROR: Failed building wheel for dnsq
#25 55.68   Running setup.py clean for dnsq
#25 55.87   Building wheel for docopt (setup.py): started
#25 56.04   Building wheel for docopt (setup.py): finished with status 'error'
#25 56.04   error: subprocess-exited-with-error
#25 56.04   
#25 56.04   × python setup.py bdist_wheel did not run successfully.
#25 56.04   │ exit code: 1
#25 56.04   ╰─> [6 lines of output]
#25 56.04       usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
#25 56.04          or: setup.py --help [cmd1 cmd2 ...]
#25 56.04          or: setup.py --help-commands
#25 56.04          or: setup.py cmd --help
#25 56.04       
#25 56.04       error: invalid command 'bdist_wheel'
#25 56.04       [end of output]
#25 56.04   
#25 56.04   note: This error originates from a subprocess, and is likely not a problem with pip.
#25 56.04   ERROR: Failed building wheel for docopt
#25 56.04   Running setup.py clean for docopt
#25 56.21   Building wheel for log_colorizer (setup.py): started
#25 56.38   Building wheel for log_colorizer (setup.py): finished with status 'error'
#25 56.38   error: subprocess-exited-with-error
#25 56.38   
#25 56.38   × python setup.py bdist_wheel did not run successfully.
#25 56.38   │ exit code: 1
#25 56.38   ╰─> [6 lines of output]
#25 56.38       usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
#25 56.38          or: setup.py --help [cmd1 cmd2 ...]
#25 56.38          or: setup.py --help-commands
#25 56.38          or: setup.py cmd --help
#25 56.38       
#25 56.38       error: invalid command 'bdist_wheel'
#25 56.38       [end of output]
#25 56.38   
#25 56.38   note: This error originates from a subprocess, and is likely not a problem with pip.
#25 56.38   ERROR: Failed building wheel for log_colorizer
#25 56.38   Running setup.py clean for log_colorizer
#25 56.54   Building wheel for importmagic3 (setup.py): started
#25 56.71   Building wheel for importmagic3 (setup.py): finished with status 'error'
#25 56.71   error: subprocess-exited-with-error
#25 56.71   
#25 56.71   × python setup.py bdist_wheel did not run successfully.
#25 56.71   │ exit code: 1
#25 56.71   ╰─> [6 lines of output]
#25 56.71       usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
#25 56.71          or: setup.py --help [cmd1 cmd2 ...]
#25 56.71          or: setup.py --help-commands
#25 56.71          or: setup.py cmd --help
#25 56.71       
#25 56.71       error: invalid command 'bdist_wheel'
#25 56.71       [end of output]
#25 56.71   
#25 56.71   note: This error originates from a subprocess, and is likely not a problem with pip.
#25 56.71   ERROR: Failed building wheel for importmagic3
...
```

Info @wt-io-it