### PR TITLE
[FIX] Error psycopg2 when building 15.0 images

### DIFF
--- a/build.d/700-odoo-install
+++ b/build.d/700-odoo-install
@@ -7,7 +7,7 @@ log INFO Installing Odoo from $src
 # For development you could want to avoid installing Odoo to speed up build
 if [ "$PIP_INSTALL_ODOO" == true ]; then
     args="--no-cache-dir"
-    pip install $args --editable $src
+    pip install $args --editable $src --config-setting=editable_mode=compat
 else
     log WARNING Blindly symlinking odoo executable
     bin=$src/odoo-bin


### PR DESCRIPTION
Error when 15.0 is building:

```
#9 317.3 Collecting psycopg2>=2.2
#9 317.3   Downloading psycopg2-2.9.10.tar.gz (385 kB)
#9 317.3      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 385.7/385.7 kB 269.5 MB/s eta 0:00:00
#9 317.4   Preparing metadata (setup.py): started
#9 317.6   Preparing metadata (setup.py): finished with status 'error'
#9 317.6   error: subprocess-exited-with-error
#9 317.6   
#9 317.6   × python setup.py egg_info did not run successfully.
#9 317.6   │ exit code: 1
#9 317.6   ╰─> [23 lines of output]
#9 317.6       running egg_info
#9 317.6       creating /tmp/pip-pip-egg-info-rrag0c7u/psycopg2.egg-info
#9 317.6       writing /tmp/pip-pip-egg-info-rrag0c7u/psycopg2.egg-info/PKG-INFO
#9 317.6       writing dependency_links to /tmp/pip-pip-egg-info-rrag0c7u/psycopg2.egg-info/dependency_links.txt
#9 317.6       writing top-level names to /tmp/pip-pip-egg-info-rrag0c7u/psycopg2.egg-info/top_level.txt
#9 317.6       writing manifest file '/tmp/pip-pip-egg-info-rrag0c7u/psycopg2.egg-info/SOURCES.txt'
#9 317.6       
#9 317.6       Error: pg_config executable not found.
#9 317.6       
#9 317.6       pg_config is required to build psycopg2 from source.  Please add the directory
#9 317.6       containing pg_config to the $PATH or specify the full executable path with the
#9 317.6       option:
#9 317.6       
#9 317.6           python setup.py build_ext --pg-config /path/to/pg_config build ...
#9 317.6       
#9 317.6       or with the pg_config option in 'setup.cfg'.
#9 317.6       
#9 317.6       If you prefer to avoid building psycopg2 from source, please install the PyPI
#9 317.6       'psycopg2-binary' package instead.
#9 317.6       
#9 317.6       For further information please check the 'doc/src/install.rst' file (also at
#9 317.6       <https://www.psycopg.org/docs/install.html>).
#9 317.6       
#9 317.6       [end of output] 
``` 

I have also tryid pre-installing psycopg-binary but keeps trying to install and compile non binary version.

ping @ap-wtioit @Tardo