### PR TITLE
[FIX] Test Environment: Don't use published 'onbuild' image

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -70,14 +70,14 @@ files = [
 
 [[package]]
 name = "platformdirs"
-version = "4.3.7"
+version = "4.3.8"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "platformdirs-4.3.7-py3-none-any.whl", hash = "sha256:a03875334331946f13c549dbd8f4bac7a13a50a895a0eb1e8c6a8ace80d40a94"},
-    {file = "platformdirs-4.3.7.tar.gz", hash = "sha256:eb437d586b6a0986388f0d6f74aa0cde27b48d0e3d66843640bfb6bdcdb6e351"},
+    {file = "platformdirs-4.3.8-py3-none-any.whl", hash = "sha256:ff7059bb7eb1179e2685604f4aaf157cfd9535242bd23742eadc3c13542139b4"},
+    {file = "platformdirs-4.3.8.tar.gz", hash = "sha256:3d512d96e16bcb959a814c9f348431070822a6496326a4be0911c40b5a74c2bc"},
 ]
 
 [package.extras]
@@ -217,14 +217,14 @@ files = [
 
 [[package]]
 name = "virtualenv"
-version = "20.30.0"
+version = "20.31.2"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "virtualenv-20.30.0-py3-none-any.whl", hash = "sha256:e34302959180fca3af42d1800df014b35019490b119eba981af27f2fa486e5d6"},
-    {file = "virtualenv-20.30.0.tar.gz", hash = "sha256:800863162bcaa5450a6e4d721049730e7f2dae07720e0902b0e4040bd6f9ada8"},
+    {file = "virtualenv-20.31.2-py3-none-any.whl", hash = "sha256:36efd0d9650ee985f0cad72065001e66d49a6f24eb44d98980f630686243cf11"},
+    {file = "virtualenv-20.31.2.tar.gz", hash = "sha256:e10c0a9d02835e592521be48b332b6caee6887f332c111aa79a09b9e79efc2af"},
 ]
 
 [package.dependencies]
@@ -238,5 +238,5 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 
 [metadata]
 lock-version = "2.1"
-python-versions = "^3.11"
-content-hash = "02e3335edeea832d1ec8747c019d764b884c05704b1ab292c7d2d27b2e21d86b"
+python-versions = "^3.9"
+content-hash = "4e323a4a9e17ff1a3a4038e5c65bfa6562caad1b578404c97503461017324860"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ description = "Docker Odoo Base, a highly opinionated image ready to put Odoo in
 authors = ["Tecnativa"]
 
 [tool.poetry.dependencies]
-python = "^3.11"
+python = "^3.9"
 
 [tool.poetry.group.dev.dependencies]
 plumbum = "^1.6.9"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -54,6 +54,27 @@ def matrix(
 
 
 class ScaffoldingCase(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # We build the “onbuild” images with the latest changes for
+        # testing instead of relying on the latest published ones.
+        for ODOO_VER in ODOO_VERSIONS:
+            print(f"Building ${ODOO_VER}-onbuild image...")
+            Popen(
+                (
+                    "docker",
+                    "build",
+                    "-t",
+                    f"tecnativa/doodba:{ODOO_VER}-onbuild",
+                    "-f",
+                    f"{ODOO_VER}.Dockerfile",
+                    "--target",
+                    "onbuild",
+                    ".",
+                ),
+                cwd=os.getcwd(),
+            ).wait()
+
     def setUp(self):
         super().setUp()
         self.compose_run = ("docker", "compose", "run", "--rm", "odoo")


### PR DESCRIPTION
Without these changes, the ‘onbuild’ docker hub image is used when launching the tests: https://hub.docker.com/r/tecnativa/doodba/tags

I consider this a bug. We are interested in testing the latest changes and testing the new changes on the new image, not on the last one that managed to be released. I see it as a mismatch between what I think I'm testing and what I'm actually testing.... and it can happen as now, that a problem is not detected when changes are made but when merging and launching new tests.