### PR TITLE
[IMP] Using test images on test-pr stage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,60 +27,11 @@ jobs:
           key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
       - uses: pre-commit/action@v3.0.1
 
-  test:
-    runs-on: ubuntu-24.04
-    needs: pre-commit
-    strategy:
-      fail-fast: false
-      matrix:
-        # Test modern Odoo versions with latest Postgres version
-        odoo_version: ["18.0"]
-        pg_version: ["16"]
-        python_version: ["3.10"]
-        include:
-          # Older odoo versions don't support latest postgres and Python versions
-          - odoo_version: "17.0"
-            pg_version: "15"
-            python_version: "3.10"
-          - odoo_version: "16.0"
-            pg_version: "14"
-            python_version: "3.10"
-          - odoo_version: "15.0"
-            pg_version: "14"
-            python_version: "3.9"
-          - odoo_version: "14.0"
-            pg_version: "14"
-            python_version: "3.9"
-          - odoo_version: "13.0"
-            pg_version: "14"
-            python_version: "3.9"
-    env:
-      # Other variables to configure tests and execution environment
-      DOCKER_BUILDKIT: 1
-      PG_VERSIONS: ${{ matrix.pg_version }}
-      ODOO_MINOR: ${{ matrix.odoo_version }}
-      DOCKER_TAG: ${{ matrix.odoo_version }}
-    steps:
-      # Prepare
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python_version }}
-      - uses: docker/setup-compose-action@v1
-        with:
-          version: latest
-      # Install dev and test dependencies
-      - run: pip install poetry
-      - name: Patch $PATH
-        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
-      - run: poetry install
-      # Test
-      - run: poetry run python -m unittest -v tests
-
   build-push-pr:
+    # Build & push PR images so tests and local dev can pull them
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
-    needs: test
+    needs: pre-commit
     strategy:
       fail-fast: false
       matrix:
@@ -167,8 +118,8 @@ jobs:
             ${{ github.repository == 'tecnativa/doodba' &&
             github.event.pull_request.head.repo.full_name == github.repository }}
           tags: |
-            ${{ env.DOCKER_REPO }}:${{ matrix.odoo_version }}-onbuild-pr-${{ github.event.pull_request.number }}-test
-            ${{ env.GHCR_HOST }}/${{ env.DOCKER_REPO }}${{ env.DOCKER_REPO_SUFFIX }}:${{ matrix.odoo_version }}-onbuild-pr-${{ github.event.pull_request.number }}-test
+            ${{ env.DOCKER_REPO }}:${{ matrix.odoo_version }}-pr-${{ github.event.pull_request.number }}-test-onbuild
+            ${{ env.GHCR_HOST }}/${{ env.DOCKER_REPO }}${{ env.DOCKER_REPO_SUFFIX }}:${{ matrix.odoo_version }}-pr-${{ github.event.pull_request.number }}-test-onbuild
           target: onbuild
           build-args: |
             VCS_REF=${{ github.sha }}
@@ -179,7 +130,99 @@ jobs:
           docker system prune -af --volumes || true
           docker builder prune -af || true
 
+  test-pr:
+    # Run tests in PR using the freshly pushed images
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    needs: build-push-pr
+    strategy:
+      fail-fast: false
+      matrix:
+        odoo_version: ["18.0"]
+        pg_version: ["16"]
+        python_version: ["3.10"]
+        include:
+          - odoo_version: "17.0"
+            pg_version: "15"
+            python_version: "3.10"
+          - odoo_version: "16.0"
+            pg_version: "14"
+            python_version: "3.10"
+          - odoo_version: "15.0"
+            pg_version: "14"
+            python_version: "3.9"
+          - odoo_version: "14.0"
+            pg_version: "14"
+            python_version: "3.9"
+          - odoo_version: "13.0"
+            pg_version: "14"
+            python_version: "3.9"
+    env:
+      DOCKER_BUILDKIT: 1
+      PG_VERSIONS: ${{ matrix.pg_version }}
+      ODOO_MINOR:
+        ${{ matrix.odoo_version }}-pr-${{ github.event.pull_request.number }}-test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python_version }}
+      - uses: docker/setup-compose-action@v1
+        with:
+          version: latest
+      - run: pip install poetry
+      - name: Patch $PATH
+        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+      - run: poetry install
+      - run: poetry run python -m unittest -v tests
+
+  test:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-24.04
+    needs: pre-commit
+    strategy:
+      fail-fast: false
+      matrix:
+        odoo_version: ["18.0"]
+        pg_version: ["16"]
+        python_version: ["3.10"]
+        include:
+          - odoo_version: "17.0"
+            pg_version: "15"
+            python_version: "3.10"
+          - odoo_version: "16.0"
+            pg_version: "14"
+            python_version: "3.10"
+          - odoo_version: "15.0"
+            pg_version: "14"
+            python_version: "3.9"
+          - odoo_version: "14.0"
+            pg_version: "14"
+            python_version: "3.9"
+          - odoo_version: "13.0"
+            pg_version: "14"
+            python_version: "3.9"
+    env:
+      DOCKER_BUILDKIT: 1
+      PG_VERSIONS: ${{ matrix.pg_version }}
+      ODOO_MINOR: ${{ matrix.odoo_version }}
+      DOCKER_TAG: ${{ matrix.odoo_version }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python_version }}
+      - uses: docker/setup-compose-action@v1
+        with:
+          version: latest
+      - run: pip install poetry
+      - name: Patch $PATH
+        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+      - run: poetry install
+      - run: poetry run python -m unittest -v tests
+
   build-push-official:
+    # Only publish final images from master after tests pass
     if: github.repository == 'tecnativa/doodba' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-24.04
     needs: test
@@ -202,7 +245,7 @@ jobs:
           - odoo_version: "13.0"
             platforms: "linux/amd64"
     env:
-      # Indicates what's the equivalent to tecnativa/doodba:latest image
+      # Indicates what tag matches tecnativa/doodba:latest
       LATEST_RELEASE: "18.0"
       # Define the docker hub repository location and github container registry host
       DOCKER_REPO: tecnativa/doodba


### PR DESCRIPTION
Build & push Docker images in PRs before running tests, introducing build-push-pr → test-pr so tests (and local dev) use the freshly built tags.
Official images remain published only from master after tests succeed.