### PR TITLE
[IMP] Add healthcheck

### DIFF
--- a/11.0.Dockerfile
+++ b/11.0.Dockerfile
@@ -162,7 +162,7 @@ LABEL org.label-schema.schema-version="$VERSION" \
       org.label-schema.build-date="$BUILD_DATE" \
       org.label-schema.vcs-ref="$VCS_REF" \
       org.label-schema.vcs-url="https://github.com/Tecnativa/doodba"
-
+HEALTHCHECK --interval=1m --timeout=1s --start-period=30s --start-interval=1s --retries=3 CMD [ "/usr/local/bin/healthcheck" ]
 # Onbuild version, with all the magic
 FROM base AS onbuild
 

--- a/12.0.Dockerfile
+++ b/12.0.Dockerfile
@@ -158,6 +158,8 @@ LABEL org.label-schema.schema-version="$VERSION" \
       org.label-schema.vcs-ref="$VCS_REF" \
       org.label-schema.vcs-url="https://github.com/Tecnativa/doodba"
 
+HEALTHCHECK --interval=1m --timeout=1s --start-period=30s --start-interval=1s --retries=3 CMD [ "/usr/local/bin/healthcheck" ]
+
 # Onbuild version, with all the magic
 FROM base AS onbuild
 

--- a/13.0.Dockerfile
+++ b/13.0.Dockerfile
@@ -162,6 +162,8 @@ LABEL org.label-schema.schema-version="$VERSION" \
       org.label-schema.vcs-ref="$VCS_REF" \
       org.label-schema.vcs-url="https://github.com/Tecnativa/doodba"
 
+HEALTHCHECK --interval=1m --timeout=1s --start-period=30s --start-interval=1s --retries=3 CMD [ "/usr/local/bin/healthcheck" ]
+
 # Onbuild version, with all the magic
 FROM base AS onbuild
 

--- a/14.0.Dockerfile
+++ b/14.0.Dockerfile
@@ -179,6 +179,8 @@ LABEL org.label-schema.schema-version="$VERSION" \
       org.label-schema.vcs-ref="$VCS_REF" \
       org.label-schema.vcs-url="https://github.com/Tecnativa/doodba"
 
+HEALTHCHECK --interval=1m --timeout=1s --start-period=30s --start-interval=1s --retries=3 CMD [ "/usr/local/bin/healthcheck" ]
+
 # Onbuild version, with all the magic
 FROM base AS onbuild
 

--- a/15.0.Dockerfile
+++ b/15.0.Dockerfile
@@ -176,6 +176,8 @@ LABEL org.label-schema.schema-version="$VERSION" \
       org.label-schema.vcs-ref="$VCS_REF" \
       org.label-schema.vcs-url="https://github.com/Tecnativa/doodba"
 
+HEALTHCHECK --interval=1m --timeout=1s --start-period=30s --start-interval=1s --retries=3 CMD [ "/usr/local/bin/healthcheck" ]
+
 # Onbuild version, with all the magic
 FROM base AS onbuild
 

--- a/16.0.Dockerfile
+++ b/16.0.Dockerfile
@@ -181,6 +181,8 @@ LABEL org.label-schema.schema-version="$VERSION" \
       org.label-schema.vcs-ref="$VCS_REF" \
       org.label-schema.vcs-url="https://github.com/Tecnativa/doodba"
 
+HEALTHCHECK --interval=1m --timeout=1s --start-period=30s --start-interval=1s --retries=3 CMD [ "/usr/local/bin/healthcheck" ]
+
 # Onbuild version, with all the magic
 FROM base AS onbuild
 

--- a/17.0.Dockerfile
+++ b/17.0.Dockerfile
@@ -180,6 +180,8 @@ LABEL org.label-schema.schema-version="$VERSION" \
       org.label-schema.vcs-ref="$VCS_REF" \
       org.label-schema.vcs-url="https://github.com/Tecnativa/doodba"
 
+HEALTHCHECK --interval=1m --timeout=1s --start-period=30s --start-interval=1s --retries=3 CMD [ "/usr/local/bin/healthcheck" ]
+
 # Onbuild version, with all the magic
 FROM base AS onbuild
 

--- a/18.0.Dockerfile
+++ b/18.0.Dockerfile
@@ -182,6 +182,8 @@ LABEL org.label-schema.schema-version="$VERSION" \
       org.label-schema.vcs-ref="$VCS_REF" \
       org.label-schema.vcs-url="https://github.com/Tecnativa/doodba"
 
+HEALTHCHECK --interval=1m --timeout=1s --start-period=30s --start-interval=1s --retries=3 CMD [ "/usr/local/bin/healthcheck" ]
+
 # Onbuild version, with all the magic
 FROM base AS onbuild
 

--- a/19.0.Dockerfile
+++ b/19.0.Dockerfile
@@ -181,6 +181,8 @@ LABEL org.label-schema.schema-version="$VERSION" \
       org.label-schema.vcs-ref="$VCS_REF" \
       org.label-schema.vcs-url="https://github.com/Tecnativa/doodba"
 
+HEALTHCHECK --interval=1m --timeout=1s --start-period=30s --start-interval=1s --retries=3 CMD [ "/usr/local/bin/healthcheck" ]
+
 # Onbuild version, with all the magic
 FROM base AS onbuild
 

--- a/bin/healthcheck
+++ b/bin/healthcheck
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if (( ${ODOO_VERSION/%.0} > 13));then
+    curl -sf http://localhost:8069/web/health || exit 1
+else
+    curl -sf http://localhost:8069/web/database/selector || exit 1
+fi


### PR DESCRIPTION
Adds a Healthcheck built into the image, this can be used in docker compose, kubernetes or other deployment systems to know if the container is actually working as expected.
@tecnativa @victoralmau @CristianoMafraJunior
