### PR TITLE
[IMP] healthcheck: add healthcheck for odoo services

### DIFF
--- a/11.0.Dockerfile
+++ b/11.0.Dockerfile
@@ -181,6 +181,7 @@ ONBUILD RUN groupadd -g $GID odoo -o \
 # Subimage triggers
 ONBUILD ENTRYPOINT ["/opt/odoo/common/entrypoint"]
 ONBUILD CMD ["/usr/local/bin/odoo"]
+ONBUILD HEALTHCHECK CMD ["/usr/local/bin/healthcheck"]
 ONBUILD ARG AGGREGATE=true
 ONBUILD ARG DEFAULT_REPO_PATTERN="https://github.com/OCA/{}.git"
 ONBUILD ARG DEFAULT_REPO_PATTERN_ODOO="https://github.com/OCA/OCB.git"

--- a/11.0.Dockerfile
+++ b/11.0.Dockerfile
@@ -42,19 +42,21 @@ RUN sed -i 's,http://deb.debian.org,http://archive.debian.org,g;s,http://securit
 RUN apt-get -qq update \
     && apt-get -yqq upgrade \
     && apt-get install -yqq --no-install-recommends \
+        apt-transport-https \
+        ca-certificates \
         chromium \
         fonts-liberation2 \
         gettext \
         gnupg2 \
         locales-all \
-        ruby-compass \
         nano \
+        net-tools \
+        procps \
+        ruby-compass \
         ruby \
         telnet \
         vim \
         zlibc \
-        apt-transport-https \
-        ca-certificates \
     && echo 'deb https://apt-archive.postgresql.org/pub/repos/apt stretch-pgdg main' >> /etc/apt/sources.list.d/postgresql.list \
     && curl -SL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
     && curl https://bootstrap.pypa.io/pip/3.5/get-pip.py | python3 /dev/stdin \
@@ -182,6 +184,7 @@ ONBUILD RUN groupadd -g $GID odoo -o \
 # Subimage triggers
 ONBUILD ENTRYPOINT ["/opt/odoo/common/entrypoint"]
 ONBUILD CMD ["/usr/local/bin/odoo"]
+ONBUILD HEALTHCHECK CMD ["/usr/local/bin/healthcheck"]
 ONBUILD ARG AGGREGATE=true
 ONBUILD ARG DEFAULT_REPO_PATTERN="https://github.com/OCA/{}.git"
 ONBUILD ARG DEFAULT_REPO_PATTERN_ODOO="https://github.com/OCA/OCB.git"

--- a/12.0.Dockerfile
+++ b/12.0.Dockerfile
@@ -176,6 +176,7 @@ ONBUILD RUN groupadd -g $GID odoo -o \
 # Subimage triggers
 ONBUILD ENTRYPOINT ["/opt/odoo/common/entrypoint"]
 ONBUILD CMD ["/usr/local/bin/odoo"]
+ONBUILD HEALTHCHECK CMD ["/usr/local/bin/healthcheck"]
 ONBUILD ARG AGGREGATE=true
 ONBUILD ARG DEFAULT_REPO_PATTERN="https://github.com/OCA/{}.git"
 ONBUILD ARG DEFAULT_REPO_PATTERN_ODOO="https://github.com/OCA/OCB.git"

--- a/12.0.Dockerfile
+++ b/12.0.Dockerfile
@@ -42,6 +42,8 @@ RUN sed -i 's,http://deb.debian.org,http://archive.debian.org,g;s,http://securit
 RUN apt-get -qq update \
     && apt-get -yqq upgrade \
     && apt-get install -yqq --no-install-recommends \
+        apt-transport-https \
+        ca-certificates \
         chromium \
         ffmpeg \
         fonts-liberation2 \
@@ -49,12 +51,12 @@ RUN apt-get -qq update \
         gnupg2 \
         locales-all \
         nano \
+        net-tools \
+        procps \
         ruby \
         telnet \
         vim \
         zlibc \
-        apt-transport-https \
-        ca-certificates \
     && echo 'deb https://apt-archive.postgresql.org/pub/repos/apt stretch-pgdg main' >> /etc/apt/sources.list.d/postgresql.list \
     && curl -SL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
     && curl https://bootstrap.pypa.io/pip/3.5/get-pip.py | python3 /dev/stdin \
@@ -177,6 +179,7 @@ ONBUILD RUN groupadd -g $GID odoo -o \
 # Subimage triggers
 ONBUILD ENTRYPOINT ["/opt/odoo/common/entrypoint"]
 ONBUILD CMD ["/usr/local/bin/odoo"]
+ONBUILD HEALTHCHECK CMD ["/usr/local/bin/healthcheck"]
 ONBUILD ARG AGGREGATE=true
 ONBUILD ARG DEFAULT_REPO_PATTERN="https://github.com/OCA/{}.git"
 ONBUILD ARG DEFAULT_REPO_PATTERN_ODOO="https://github.com/OCA/OCB.git"

--- a/13.0.Dockerfile
+++ b/13.0.Dockerfile
@@ -180,6 +180,7 @@ ONBUILD RUN groupadd -g $GID odoo -o \
 # Subimage triggers
 ONBUILD ENTRYPOINT ["/opt/odoo/common/entrypoint"]
 ONBUILD CMD ["/usr/local/bin/odoo"]
+ONBUILD HEALTHCHECK CMD ["/usr/local/bin/healthcheck"]
 ONBUILD ARG AGGREGATE=true
 ONBUILD ARG DEFAULT_REPO_PATTERN="https://github.com/OCA/{}.git"
 ONBUILD ARG DEFAULT_REPO_PATTERN_ODOO="https://github.com/OCA/OCB.git"

--- a/13.0.Dockerfile
+++ b/13.0.Dockerfile
@@ -57,8 +57,10 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,id=apt-lists-${TARGETARCH}-${OD
         gnupg2 \
         locales-all \
         nano \
+        net-tools \
         npm \
         openssh-client \
+        procps \
         telnet \
         vim \
         zlibc \
@@ -185,6 +187,7 @@ ONBUILD RUN groupadd -g $GID odoo -o \
 # Subimage triggers
 ONBUILD ENTRYPOINT ["/opt/odoo/common/entrypoint"]
 ONBUILD CMD ["/usr/local/bin/odoo"]
+ONBUILD HEALTHCHECK CMD ["/usr/local/bin/healthcheck"]
 ONBUILD ARG TARGETARCH
 ONBUILD ARG AGGREGATE=true
 ONBUILD ARG DEFAULT_REPO_PATTERN="https://github.com/OCA/{}.git"

--- a/14.0.Dockerfile
+++ b/14.0.Dockerfile
@@ -197,6 +197,7 @@ ONBUILD RUN groupadd -g $GID odoo -o \
 # Subimage triggers
 ONBUILD ENTRYPOINT ["/opt/odoo/common/entrypoint"]
 ONBUILD CMD ["/usr/local/bin/odoo"]
+ONBUILD HEALTHCHECK CMD ["/usr/local/bin/healthcheck"]
 ONBUILD ARG AGGREGATE=true
 ONBUILD ARG DEFAULT_REPO_PATTERN="https://github.com/OCA/{}.git"
 ONBUILD ARG DEFAULT_REPO_PATTERN_ODOO="https://github.com/OCA/OCB.git"

--- a/14.0.Dockerfile
+++ b/14.0.Dockerfile
@@ -72,8 +72,11 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,id=apt-lists-${TARGETARCH}-${OD
         gnupg2 \
         locales-all \
         nano \
+        net-tools \
         npm \
         openssh-client \
+        procps \
+        net-tools \
         telnet \
         vim \
         zlibc \
@@ -201,6 +204,7 @@ ONBUILD RUN groupadd -g $GID odoo -o \
 # Subimage triggers
 ONBUILD ENTRYPOINT ["/opt/odoo/common/entrypoint"]
 ONBUILD CMD ["/usr/local/bin/odoo"]
+ONBUILD HEALTHCHECK CMD ["/usr/local/bin/healthcheck"]
 ONBUILD ARG TARGETARCH
 ONBUILD ARG AGGREGATE=true
 ONBUILD ARG DEFAULT_REPO_PATTERN="https://github.com/OCA/{}.git"

--- a/15.0.Dockerfile
+++ b/15.0.Dockerfile
@@ -194,6 +194,7 @@ ONBUILD RUN groupadd -g $GID odoo -o \
 # Subimage triggers
 ONBUILD ENTRYPOINT ["/opt/odoo/common/entrypoint"]
 ONBUILD CMD ["/usr/local/bin/odoo"]
+ONBUILD HEALTHCHECK CMD ["/usr/local/bin/healthcheck"]
 ONBUILD ARG AGGREGATE=true
 ONBUILD ARG DEFAULT_REPO_PATTERN="https://github.com/OCA/{}.git"
 ONBUILD ARG DEFAULT_REPO_PATTERN_ODOO="https://github.com/OCA/OCB.git"

--- a/15.0.Dockerfile
+++ b/15.0.Dockerfile
@@ -72,8 +72,10 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,id=apt-lists-${TARGETARCH}-${OD
         gnupg2 \
         locales-all \
         nano \
+        net-tools \
         npm \
         openssh-client \
+        procps \
         telnet \
         vim \
     && echo 'deb https://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main' >> /etc/apt/sources.list.d/postgresql.list \
@@ -200,6 +202,7 @@ ONBUILD RUN groupadd -g $GID odoo -o \
 # Subimage triggers
 ONBUILD ENTRYPOINT ["/opt/odoo/common/entrypoint"]
 ONBUILD CMD ["/usr/local/bin/odoo"]
+ONBUILD HEALTHCHECK CMD ["/usr/local/bin/healthcheck"]
 ONBUILD ARG TARGETARCH
 ONBUILD ARG AGGREGATE=true
 ONBUILD ARG DEFAULT_REPO_PATTERN="https://github.com/OCA/{}.git"

--- a/16.0.Dockerfile
+++ b/16.0.Dockerfile
@@ -199,6 +199,7 @@ ONBUILD RUN groupadd -g $GID odoo -o \
 # Subimage triggers
 ONBUILD ENTRYPOINT ["/opt/odoo/common/entrypoint"]
 ONBUILD CMD ["/usr/local/bin/odoo"]
+ONBUILD HEALTHCHECK CMD ["/usr/local/bin/healthcheck"]
 ONBUILD ARG AGGREGATE=true
 ONBUILD ARG DEFAULT_REPO_PATTERN="https://github.com/OCA/{}.git"
 ONBUILD ARG DEFAULT_REPO_PATTERN_ODOO="https://github.com/OCA/OCB.git"

--- a/16.0.Dockerfile
+++ b/16.0.Dockerfile
@@ -74,8 +74,10 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,id=apt-lists-${TARGETARCH}-${OD
         gnupg2 \
         locales-all \
         nano \
+        net-tools \
         npm \
         openssh-client \
+        procps \
         telnet \
         vim \
     && echo 'deb https://apt.postgresql.org/pub/repos/apt/ bookworm-pgdg main' >> /etc/apt/sources.list.d/postgresql.list \
@@ -203,6 +205,7 @@ ONBUILD RUN groupadd -g $GID odoo -o \
 # Subimage triggers
 ONBUILD ENTRYPOINT ["/opt/odoo/common/entrypoint"]
 ONBUILD CMD ["/usr/local/bin/odoo"]
+ONBUILD HEALTHCHECK CMD ["/usr/local/bin/healthcheck"]
 ONBUILD ARG TARGETARCH
 ONBUILD ARG AGGREGATE=true
 ONBUILD ARG DEFAULT_REPO_PATTERN="https://github.com/OCA/{}.git"

--- a/17.0.Dockerfile
+++ b/17.0.Dockerfile
@@ -198,6 +198,7 @@ ONBUILD RUN groupadd -g $GID odoo -o \
 # Subimage triggers
 ONBUILD ENTRYPOINT ["/opt/odoo/common/entrypoint"]
 ONBUILD CMD ["/usr/local/bin/odoo"]
+ONBUILD HEALTHCHECK CMD ["/usr/local/bin/healthcheck"]
 ONBUILD ARG AGGREGATE=true
 ONBUILD ARG DEFAULT_REPO_PATTERN="https://github.com/OCA/{}.git"
 ONBUILD ARG DEFAULT_REPO_PATTERN_ODOO="https://github.com/OCA/OCB.git"

--- a/17.0.Dockerfile
+++ b/17.0.Dockerfile
@@ -73,8 +73,10 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,id=apt-lists-${TARGETARCH}-${OD
         gnupg2 \
         locales-all \
         nano \
+        net-tools \
         npm \
         openssh-client \
+        procps \
         telnet \
         vim \
     && echo 'deb https://apt.postgresql.org/pub/repos/apt/ bookworm-pgdg main' >> /etc/apt/sources.list.d/postgresql.list \
@@ -201,6 +203,7 @@ ONBUILD RUN groupadd -g $GID odoo -o \
 # Subimage triggers
 ONBUILD ENTRYPOINT ["/opt/odoo/common/entrypoint"]
 ONBUILD CMD ["/usr/local/bin/odoo"]
+ONBUILD HEALTHCHECK CMD ["/usr/local/bin/healthcheck"]
 ONBUILD ARG TARGETARCH
 ONBUILD ARG AGGREGATE=true
 ONBUILD ARG DEFAULT_REPO_PATTERN="https://github.com/OCA/{}.git"

--- a/18.0.Dockerfile
+++ b/18.0.Dockerfile
@@ -200,6 +200,7 @@ ONBUILD RUN groupadd -g $GID odoo -o \
 # Subimage triggers
 ONBUILD ENTRYPOINT ["/opt/odoo/common/entrypoint"]
 ONBUILD CMD ["/usr/local/bin/odoo"]
+ONBUILD HEALTHCHECK CMD ["/usr/local/bin/healthcheck"]
 ONBUILD ARG AGGREGATE=true
 ONBUILD ARG DEFAULT_REPO_PATTERN="https://github.com/OCA/{}.git"
 ONBUILD ARG DEFAULT_REPO_PATTERN_ODOO="https://github.com/OCA/OCB.git"

--- a/18.0.Dockerfile
+++ b/18.0.Dockerfile
@@ -75,8 +75,10 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,id=apt-lists-${TARGETARCH}-${OD
         gnupg2 \
         locales-all \
         nano \
+        net-tools \
         npm \
         openssh-client \
+        procps \
         telnet \
         vim \
     && echo 'deb https://apt.postgresql.org/pub/repos/apt/ bookworm-pgdg main' >> /etc/apt/sources.list.d/postgresql.list \
@@ -205,6 +207,7 @@ ONBUILD RUN groupadd -g $GID odoo -o \
 # Subimage triggers
 ONBUILD ENTRYPOINT ["/opt/odoo/common/entrypoint"]
 ONBUILD CMD ["/usr/local/bin/odoo"]
+ONBUILD HEALTHCHECK CMD ["/usr/local/bin/healthcheck"]
 ONBUILD ARG TARGETARCH
 ONBUILD ARG AGGREGATE=true
 ONBUILD ARG DEFAULT_REPO_PATTERN="https://github.com/OCA/{}.git"

--- a/19.0.Dockerfile
+++ b/19.0.Dockerfile
@@ -199,6 +199,7 @@ ONBUILD RUN groupadd -g $GID odoo -o \
 # Subimage triggers
 ONBUILD ENTRYPOINT ["/opt/odoo/common/entrypoint"]
 ONBUILD CMD ["/usr/local/bin/odoo"]
+ONBUILD HEALTHCHECK CMD ["/usr/local/bin/healthcheck"]
 ONBUILD ARG AGGREGATE=true
 ONBUILD ARG DEFAULT_REPO_PATTERN="https://github.com/OCA/{}.git"
 ONBUILD ARG DEFAULT_REPO_PATTERN_ODOO="https://github.com/OCA/OCB.git"

--- a/19.0.Dockerfile
+++ b/19.0.Dockerfile
@@ -75,8 +75,10 @@ RUN --mount=target=/var/lib/apt/lists,type=cache,id=apt-lists-${TARGETARCH}-${OD
         gnupg2 \
         locales-all \
         nano \
+        net-tools \
         npm \
         openssh-client \
+        procps \
         telnet \
         vim \
     && echo 'deb https://apt.postgresql.org/pub/repos/apt/ bookworm-pgdg main' >> /etc/apt/sources.list.d/postgresql.list \
@@ -205,6 +207,7 @@ ONBUILD RUN groupadd -g $GID odoo -o \
 # Subimage triggers
 ONBUILD ENTRYPOINT ["/opt/odoo/common/entrypoint"]
 ONBUILD CMD ["/usr/local/bin/odoo"]
+ONBUILD HEALTHCHECK CMD ["/usr/local/bin/healthcheck"]
 ONBUILD ARG TARGETARCH
 ONBUILD ARG AGGREGATE=true
 ONBUILD ARG DEFAULT_REPO_PATTERN="https://github.com/OCA/{}.git"

--- a/bin/healthcheck
+++ b/bin/healthcheck
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+# check that odoo
+# * bin can be found
+# * if not just an odoo-click- script is running
+#   and not just tests are running
+#   * has process(es) running
+#   *  if http_enabled
+#     * has http ports open
+#     * if multithreaded
+#       * check that longpolling port is open
+#       * check that cron threads are running
+#       * check that http workers are available
+#       * check that not all threads are occupied
+# * db connection is working
+
+if [[ $1 == '-v' ]]; then
+    OUTPUT=""
+    set -x
+else
+    OUTPUT=" >/dev/null"
+fi
+
+errors=0
+skipped=()
+ODOO_CMD=$(which odoo)
+# store cookies in a file that is persisted through restarts
+CURL_COOKIE_JAR="/var/lib/odoo/${PGDATABASE}-healthcheck-cookies.txt"
+if [[ ! -e "$CURL_COOKIE_JAR" ]]; then
+    touch "$CURL_COOKIE_JAR"
+fi
+ONLY_CLICK_ODOO_RUNNING="false"
+ONLY_TEST_RUNNING="false"
+
+function is_skipped() {
+    local skipped_item
+    for skipped_item in "${skipped[@]}"; do
+        if [[ $skipped_item == "$*" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+function check() {
+    local status errors_at_start new_errors
+    errors_at_start=$errors
+    "$@"
+    status=$?
+    errors=$((errors + status))
+    new_errors=$((errors - errors_at_start))
+    if [[ $status == 0 && $new_errors != 0 ]]; then
+        # errors triggered in subchecks also should affect our status
+        status=$new_errors
+    fi
+    if [[ $# == 1 ]]; then
+        if [[ $status != 0 ]]; then
+            echo "$* FAILED"
+        elif is_skipped "$*" ; then
+            echo "$* SKIPPED"
+        else
+            echo "$* OK"
+        fi
+    fi
+
+    return $status
+}
+
+function get_odoo_value() {
+    local argument config argument_value config_value value default_value
+
+    argument=$1
+    config=${2:-$argument}
+    default_value=${3:-}
+
+    argument_value=$(ps fax 2>/dev/null | grep -v grep | grep "$ODOO_CMD" | grep -- '--'"$argument"'\([= ][0-9]\|$\| --\)' | sed 's/.*--'"$argument"'[= ]\([0-9]\+\).*/\1/' | sed 's/.*\(--'"$argument"'\)\($\| --.*\)/\1/' | sort | uniq)
+    config_value=$(grep -R '^'"$config"' = \([0-9]\|true\|false\)' /opt/odoo/auto/odoo.conf | sed 's/'"$config"' = \([0-9]\+\|true\|false\).*/\1/')
+    value=${argument_value:-$config_value}
+
+    echo "${value:-$default_value}"
+}
+
+function get_odoo_workers() {
+    get_odoo_value workers
+}
+
+function get_odoo_cron_threads() {
+    get_odoo_value max-cron-threads max_cron_threads 2
+}
+
+function get_odoo_http_enabled() {
+    local no_xmlrpc no_http
+    no_xmlrpc=$(get_odoo_value no-xmlrpc)
+    no_http=$(get_odoo_value no-http)
+    http_enabled=$(get_odoo_value - http_enabled true)
+    if [[ $no_xmlrpc || $no_http ]] ; then
+        echo "false"
+    else
+        echo "$http_enabled"
+    fi
+}
+
+function odoo_bin_exists() {
+    check test "$ODOO_CMD" != ""
+    check test -x "$ODOO_CMD"
+}
+
+function odoo_run_detection() {
+    # if click script is running
+    if ps fax 2>/dev/null | grep -v grep | grep "[ /]click-odoo-" >/dev/null; then
+        # and odoo is not running
+        if ! ps fax 2>/dev/null | grep -v grep | grep "$ODOO_CMD" | grep -v "odoo.* shell\( \|$\)" >/dev/null ; then
+            # we set the marker that only click odoo is running
+            ONLY_CLICK_ODOO_RUNNING="true"
+            echo "Only click-odoo-.* seems to be running"
+        fi
+    fi
+    # if test is running
+    if ps fax 2>/dev/null | grep -v grep | grep -E '[ /](run_tests|_jb_pytest_runner.py|pytest)' >/dev/null; then
+        # and odoo is not running
+        if ! ps fax 2>/dev/null | grep -v grep | grep "$ODOO_CMD" | grep -v "odoo.* --test-enable\( \|$\)" >/dev/null ; then
+            ONLY_TEST_RUNNING="true"
+            echo "Only test seems to be running"
+        fi
+    fi
+}
+
+function odoo_processes() {
+    if [[ $ONLY_CLICK_ODOO_RUNNING == "false" && $ONLY_TEST_RUNNING == "false" ]]; then
+        # checking for main odoo process
+        check bash -c 'ps fax 2>/dev/null | grep '"$ODOO_CMD"' | grep -v grep | grep -v "odoo.* shell\( \|$\)"'"$OUTPUT"
+        # detect if odoo is running with workers
+        if [[ $(get_odoo_workers) -gt 0 ]]; then
+            check odoo_workers
+        fi
+    else
+        skipped+=("odoo_processes")
+    fi
+}
+
+function odoo_listening_ports() {
+    if [[ $(get_odoo_http_enabled) == "true" && $ONLY_CLICK_ODOO_RUNNING == "false" && $ONLY_TEST_RUNNING == "false" ]] ; then
+        # checking that odoo port is listening
+        check bash -c 'netstat -lnp --tcp | grep :8069'"$OUTPUT"
+        if [[ $(get_odoo_workers) -gt 0 ]]; then
+            # check that odoo is listening on 8072 for longpolling
+            check bash -c 'netstat -lnp --tcp | grep :8072'"$OUTPUT"
+        fi
+    else
+        skipped+=("odoo_listening_ports")
+    fi
+}
+
+function odoo_workers() {
+    local workers
+    local cron_workers
+    local gevent_threads
+    local expected_processes
+
+    # verify that there is enough odoo/worker processes
+    gevent_threads=1
+    workers=$(get_odoo_workers)
+    cron_workers=$(get_odoo_cron_threads)
+    expected_processes=$((1 + workers + cron_workers + gevent_threads))
+    # shellcheck disable=SC2016
+    check bash -c '[[ $(ps fax 2>/dev/null | grep -v grep | grep -v "odoo.* shell\( \|$\)" | grep -c '"$ODOO_CMD"' 2>/dev/null) == '"$expected_processes"' ]]'
+}
+
+function odoo_connectivity() {
+    if [[ $(get_odoo_http_enabled) == "true" && $ONLY_CLICK_ODOO_RUNNING == "false" && $ONLY_TEST_RUNNING == "false" ]] ; then
+        check bash -c 'curl --cookie-jar "'"$CURL_COOKIE_JAR"'" --cookie "'"$CURL_COOKIE_JAR"'" --silent --show-error --fail 127.0.0.1:8069'"$OUTPUT"
+        # detect if odoo is running with workers
+        if [[ $(get_odoo_workers) -gt 0 ]]; then
+            check odoo_connectivity_longpolling
+        fi
+    else
+        skipped+=("odoo_connectivity")
+    fi
+}
+
+function odoo_connectivity_longpolling() {
+    if [[ ${ODOO_VERSION%.*} -ge 16 ]] ; then
+        # /websocket/health was introduced in Odoo version 16.0
+        check bash -c 'curl --silent --show-error --fail "http://127.0.0.1:8072/websocket/health"'"$OUTPUT"
+    else
+        check bash -c 'curl --cookie-jar "'"$CURL_COOKIE_JAR"'" --cookie "'"$CURL_COOKIE_JAR"'" --silent --show-error --fail 127.0.0.1:8072'"$OUTPUT"
+    fi
+}
+
+function postgres_connectivity() {
+    check bash -c 'timeout 1s psql -l'"$OUTPUT"
+}
+
+function odoo_installed() {
+    if [[ $(get_odoo_http_enabled) == "true" && $ONLY_CLICK_ODOO_RUNNING == "false" && $ONLY_TEST_RUNNING == "false" ]] ; then
+        # we add the db to the login url to make sure we do not get redirected upon successful installation of odoo
+        # (/web/login should display the login mask)
+        check bash -c 'curl --cookie-jar "'"$CURL_COOKIE_JAR"'" --cookie "'"$CURL_COOKIE_JAR"'" --silent --dump-header - --show-error --fail "http://127.0.0.1:8069/web/login" | grep "HTTP/1.[10] 200 OK"'"$OUTPUT"
+        check bash -c 'timeout 1s psql -l | grep " '"$PGDATABASE"' "'"$OUTPUT"
+    elif [[ $ONLY_TEST_RUNNING == "true" ]] ; then
+        # we check only the databse when tests are running
+        check bash -c 'timeout 1s psql -l | grep " '"$PGDATABASE"' "'"$OUTPUT"
+    else
+        skipped+=("odoo_installed")
+    fi
+}
+
+check odoo_bin_exists
+odoo_run_detection
+check odoo_processes
+check odoo_listening_ports
+check odoo_connectivity
+check postgres_connectivity
+check odoo_installed
+
+[[ $errors == 0 ]]
+exit $?

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -880,6 +880,122 @@ class ScaffoldingCase(unittest.TestCase):
                 ),
             )
 
+    def test_healthcheck(self):
+        healthcheck_dir = join(SCAFFOLDINGS_DIR, "healthcheck")
+        for sub_env in matrix():
+            self.compose_test(
+                healthcheck_dir,
+                sub_env,
+                # verify that healthcheck fails if odoo is not running
+                (
+                    "bash",
+                    "-c",
+                    "if healthcheck; then echo 'healthcheck is healthy without odoo started' 1>&2; exit 1; fi",
+                ),
+                # verify that healthcheck is working and becomes healthy when odoo is starting
+                (
+                    "timeout",
+                    "120s",
+                    "bash",
+                    "-c",
+                    "odoo & until healthcheck; do sleep 3; done;",
+                ),
+                # verify that healthcheck is working with DB_FILTER .*
+                (
+                    "timeout",
+                    "30s",
+                    "bash",
+                    "-c",
+                    "DB_FILTER='.*' odoo & until healthcheck; do sleep 3; done;",
+                ),
+                # verify that healthcheck is working with workers
+                (
+                    "timeout",
+                    "30s",
+                    "bash",
+                    "-c",
+                    "odoo --workers 2 & until healthcheck; do sleep 3; done",
+                ),
+                # verify that healthcheck is working with workers and DB_FILTER .*
+                (
+                    "timeout",
+                    "30s",
+                    "bash",
+                    "-c",
+                    "DB_FILTER='.*' odoo --workers 2 & until healthcheck; do sleep 3; done",
+                ),
+                # verify that healthcheck is working if odoo shell is launched
+                (
+                    "timeout",
+                    "30s",
+                    "bash",
+                    "-c",
+                    "odoo --workers 2 & odoo shell & until healthcheck; do sleep 3; done",
+                ),
+                # verify that healthcheck works when disabling http (and http checks are skipped)
+                (
+                    "timeout",
+                    "30s",
+                    "bash",
+                    "-c",
+                    "odoo --no-http & until healthcheck; do sleep 3; done && "
+                    "healthcheck | grep 'odoo_installed SKIPPED' && "
+                    "healthcheck | grep 'odoo_listening_ports SKIPPED' && "
+                    "healthcheck | grep 'odoo_connectivity SKIPPED'",
+                ),
+                # verify that http checks are done when running odoo normally with http
+                (
+                    "timeout",
+                    "30s",
+                    "bash",
+                    "-c",
+                    "odoo & until healthcheck; do sleep 3; done && "
+                    "healthcheck | grep 'odoo_installed OK' && "
+                    "healthcheck | grep 'odoo_listening_ports OK' && "
+                    "healthcheck | grep 'odoo_connectivity OK' && "
+                    "healthcheck | grep 'odoo_processes OK'",
+                ),
+                # verify that healthcheck works with click-odoo scripts, and odoo process check is skipped
+                (
+                    "timeout",
+                    "30s",
+                    "bash",
+                    "-c",
+                    "click-odoo-update & until healthcheck; do sleep 3; done && "
+                    "healthcheck | grep 'odoo_processes SKIPPED'",
+                ),
+                # verify that healthcheck uses cookie jar file
+                ("test", "-e", "/var/lib/odoo/prod-healthcheck-cookies.txt"),
+                # and stored a session_id cookie
+                (
+                    "grep",
+                    "-R",
+                    "session_id",
+                    "/var/lib/odoo/prod-healthcheck-cookies.txt",
+                ),
+                # and after another healthcheck cookies should not change
+                # but timestamps (column 5 in awk) do
+                (
+                    "cp",
+                    "/var/lib/odoo/prod-healthcheck-cookies.txt",
+                    "/var/lib/odoo/prod-healthcheck-cookies.txt.1",
+                ),
+                (
+                    "timeout",
+                    "30s",
+                    "bash",
+                    "-c",
+                    "odoo & until healthcheck; do sleep 3; done",
+                ),
+                (
+                    "bash",
+                    "-c",
+                    "diff"
+                    " <(awk '{$5=\"\"; print $0}' < /var/lib/odoo/prod-healthcheck-cookies.txt)"
+                    " <(awk '{$5=\"\"; print $0}' </var/lib/odoo/prod-healthcheck-cookies.txt.1)",
+                ),
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -919,6 +919,122 @@ class ScaffoldingCase(unittest.TestCase):
                 ),
             )
 
+    def test_healthcheck(self):
+        healthcheck_dir = join(SCAFFOLDINGS_DIR, "healthcheck")
+        for sub_env in matrix():
+            self.compose_test(
+                healthcheck_dir,
+                sub_env,
+                # verify that healthcheck fails if odoo is not running
+                (
+                    "bash",
+                    "-c",
+                    "if healthcheck; then echo 'healthcheck is healthy without odoo started' 1>&2; exit 1; fi",
+                ),
+                # verify that healthcheck is working and becomes healthy when odoo is starting
+                (
+                    "timeout",
+                    "120s",
+                    "bash",
+                    "-c",
+                    "odoo & until healthcheck; do sleep 3; done;",
+                ),
+                # verify that healthcheck is working with DB_FILTER .*
+                (
+                    "timeout",
+                    "30s",
+                    "bash",
+                    "-c",
+                    "DB_FILTER='.*' odoo & until healthcheck; do sleep 3; done;",
+                ),
+                # verify that healthcheck is working with workers
+                (
+                    "timeout",
+                    "30s",
+                    "bash",
+                    "-c",
+                    "odoo --workers 2 & until healthcheck; do sleep 3; done",
+                ),
+                # verify that healthcheck is working with workers and DB_FILTER .*
+                (
+                    "timeout",
+                    "30s",
+                    "bash",
+                    "-c",
+                    "DB_FILTER='.*' odoo --workers 2 & until healthcheck; do sleep 3; done",
+                ),
+                # verify that healthcheck is working if odoo shell is launched
+                (
+                    "timeout",
+                    "30s",
+                    "bash",
+                    "-c",
+                    "odoo --workers 2 & odoo shell & until healthcheck; do sleep 3; done",
+                ),
+                # verify that healthcheck works when disabling http (and http checks are skipped)
+                (
+                    "timeout",
+                    "30s",
+                    "bash",
+                    "-c",
+                    "odoo --no-http & until healthcheck; do sleep 3; done && "
+                    "healthcheck | grep 'odoo_installed SKIPPED' && "
+                    "healthcheck | grep 'odoo_listening_ports SKIPPED' && "
+                    "healthcheck | grep 'odoo_connectivity SKIPPED'",
+                ),
+                # verify that http checks are done when running odoo normally with http
+                (
+                    "timeout",
+                    "30s",
+                    "bash",
+                    "-c",
+                    "odoo & until healthcheck; do sleep 3; done && "
+                    "healthcheck | grep 'odoo_installed OK' && "
+                    "healthcheck | grep 'odoo_listening_ports OK' && "
+                    "healthcheck | grep 'odoo_connectivity OK' && "
+                    "healthcheck | grep 'odoo_processes OK'",
+                ),
+                # verify that healthcheck works with click-odoo scripts, and odoo process check is skipped
+                (
+                    "timeout",
+                    "30s",
+                    "bash",
+                    "-c",
+                    "click-odoo-update & until healthcheck; do sleep 3; done && "
+                    "healthcheck | grep 'odoo_processes SKIPPED'",
+                ),
+                # verify that healthcheck uses cookie jar file
+                ("test", "-e", "/var/lib/odoo/prod-healthcheck-cookies.txt"),
+                # and stored a session_id cookie
+                (
+                    "grep",
+                    "-R",
+                    "session_id",
+                    "/var/lib/odoo/prod-healthcheck-cookies.txt",
+                ),
+                # and after another healthcheck cookies should not change
+                # but timestamps (column 5 in awk) do
+                (
+                    "cp",
+                    "/var/lib/odoo/prod-healthcheck-cookies.txt",
+                    "/var/lib/odoo/prod-healthcheck-cookies.txt.1",
+                ),
+                (
+                    "timeout",
+                    "30s",
+                    "bash",
+                    "-c",
+                    "odoo & until healthcheck; do sleep 3; done",
+                ),
+                (
+                    "bash",
+                    "-c",
+                    "diff"
+                    " <(awk '{$5=\"\"; print $0}' < /var/lib/odoo/prod-healthcheck-cookies.txt)"
+                    " <(awk '{$5=\"\"; print $0}' </var/lib/odoo/prod-healthcheck-cookies.txt.1)",
+                ),
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/scaffoldings/healthcheck/Dockerfile
+++ b/tests/scaffoldings/healthcheck/Dockerfile
@@ -1,0 +1,2 @@
+ARG ODOO_VERSION
+FROM tecnativa/doodba:${ODOO_VERSION}-onbuild

--- a/tests/scaffoldings/healthcheck/Dockerfile
+++ b/tests/scaffoldings/healthcheck/Dockerfile
@@ -1,0 +1,2 @@
+ARG ODOO_VERSION
+FROM tecnativa/doodba:${ODOO_VERSION}-onbuild-testonly

--- a/tests/scaffoldings/healthcheck/docker-compose.yaml
+++ b/tests/scaffoldings/healthcheck/docker-compose.yaml
@@ -1,0 +1,29 @@
+services:
+  odoo:
+    build:
+      context: ./
+      args:
+        COMPILE: "false"
+        ODOO_VERSION: $ODOO_MINOR
+        WITHOUT_DEMO: "false"
+    tty: true
+    depends_on:
+      - db
+    environment:
+      PYTHONOPTIMIZE: ""
+      UNACCENT: "false"
+      DB_FILTER: "${DB_FILTER:-^prod$$}"
+    volumes:
+      - filestore:/var/lib/odoo:z
+
+  db:
+    image: postgres:${DB_VERSION}-alpine
+    environment:
+      POSTGRES_USER: odoo
+      POSTGRES_PASSWORD: odoopassword
+    volumes:
+      - db:/var/lib/postgresql/data:z
+
+volumes:
+  db:
+  filestore:


### PR DESCRIPTION
@david-banon-tecnativa i saw your pull request #700 today. in our images we already have a more featured healthcheck in place. if you want you can use our version of the healthcheck as a starting point. it was improved over the years to feature a few more usecases for doodba. so if you are using healthchecks together with [autoheal](https://github.com/willfarrell/docker-autoheal) (or some equivalent) the failed healthchecks don't kill your long runnning click scripts / tests / db dump restores.

proposing our code seems the faster route than explaining all the edge cases in a review of #700.

Info @wt-io-it