### PR TITLE
[IMP] tests: check chromium is working before testing artifacts with odoo

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -857,6 +857,18 @@ class ScaffoldingCase(unittest.TestCase):
                     "{}",
                     ";",
                 ),
+                # check chromium version
+                ("chromium", "--version"),
+                # check that chromium is working before testing with odoo
+                (
+                    "chromium",
+                    "--no-sandbox",
+                    "--headless",
+                    "--dump-dom",
+                    "--enable-logging=stderr",
+                    "--v=1",
+                    "about:blank",
+                ),
                 # install odoo base module
                 (
                     "odoo",


### PR DESCRIPTION
A small improvement in test_screencasts checking chromium is actually working before testing odoo test-artifacts creation with base module install and odoo test_screencasts.

If chromium cannot show "about:blank" there is no need to test odoo screencasts.

Slight improvement when testing #702

Info @wt-io-it