### PR TITLE
[ADD] Odoo 18+ database replica handling

### DIFF
--- a/11.0.Dockerfile
+++ b/11.0.Dockerfile
@@ -108,7 +108,8 @@ COPY build.d common/build.d
 COPY conf.d common/conf.d
 COPY entrypoint.d common/entrypoint.d
 RUN rm -f /opt/odoo/common/conf.d/60-geoip-ge17.conf \
-    && mv /opt/odoo/common/conf.d/60-geoip-lt17.conf /opt/odoo/common/conf.d/60-geoip.conf
+    && mv /opt/odoo/common/conf.d/60-geoip-lt17.conf /opt/odoo/common/conf.d/60-geoip.conf \
+    && rm -f /opt/odoo/common/conf.d/70-database-replica-ge18.conf
 RUN mkdir -p auto/addons auto/geoip custom/src/private \
     && ln /usr/local/bin/direxec common/entrypoint \
     && ln /usr/local/bin/direxec common/build \

--- a/12.0.Dockerfile
+++ b/12.0.Dockerfile
@@ -101,7 +101,8 @@ COPY build.d common/build.d
 COPY conf.d common/conf.d
 COPY entrypoint.d common/entrypoint.d
 RUN rm -f /opt/odoo/common/conf.d/60-geoip-ge17.conf \
-    && mv /opt/odoo/common/conf.d/60-geoip-lt17.conf /opt/odoo/common/conf.d/60-geoip.conf
+    && mv /opt/odoo/common/conf.d/60-geoip-lt17.conf /opt/odoo/common/conf.d/60-geoip.conf \
+    && rm -f /opt/odoo/common/conf.d/70-database-replica-ge18.conf
 RUN mkdir -p auto/addons auto/geoip custom/src/private \
     && ln /usr/local/bin/direxec common/entrypoint \
     && ln /usr/local/bin/direxec common/build \

--- a/13.0.Dockerfile
+++ b/13.0.Dockerfile
@@ -76,7 +76,8 @@ COPY build.d common/build.d
 COPY conf.d common/conf.d
 COPY entrypoint.d common/entrypoint.d
 RUN rm -f /opt/odoo/common/conf.d/60-geoip-ge17.conf \
-    && mv /opt/odoo/common/conf.d/60-geoip-lt17.conf /opt/odoo/common/conf.d/60-geoip.conf
+    && mv /opt/odoo/common/conf.d/60-geoip-lt17.conf /opt/odoo/common/conf.d/60-geoip.conf \
+    && rm -f /opt/odoo/common/conf.d/70-database-replica-ge18.conf
 RUN mkdir -p auto/addons auto/geoip custom/src/private \
     && ln /usr/local/bin/direxec common/entrypoint \
     && ln /usr/local/bin/direxec common/build \

--- a/14.0.Dockerfile
+++ b/14.0.Dockerfile
@@ -91,7 +91,8 @@ COPY build.d common/build.d
 COPY conf.d common/conf.d
 COPY entrypoint.d common/entrypoint.d
 RUN rm -f /opt/odoo/common/conf.d/60-geoip-ge17.conf \
-    && mv /opt/odoo/common/conf.d/60-geoip-lt17.conf /opt/odoo/common/conf.d/60-geoip.conf
+    && mv /opt/odoo/common/conf.d/60-geoip-lt17.conf /opt/odoo/common/conf.d/60-geoip.conf \
+    && rm -f /opt/odoo/common/conf.d/70-database-replica-ge18.conf
 RUN mkdir -p auto/addons auto/geoip custom/src/private \
     && ln /usr/local/bin/direxec common/entrypoint \
     && ln /usr/local/bin/direxec common/build \

--- a/15.0.Dockerfile
+++ b/15.0.Dockerfile
@@ -88,7 +88,8 @@ COPY build.d common/build.d
 COPY conf.d common/conf.d
 COPY entrypoint.d common/entrypoint.d
 RUN rm -f /opt/odoo/common/conf.d/60-geoip-ge17.conf \
-    && mv /opt/odoo/common/conf.d/60-geoip-lt17.conf /opt/odoo/common/conf.d/60-geoip.conf
+    && mv /opt/odoo/common/conf.d/60-geoip-lt17.conf /opt/odoo/common/conf.d/60-geoip.conf \
+    && rm -f /opt/odoo/common/conf.d/70-database-replica-ge18.conf
 RUN mkdir -p auto/addons auto/geoip custom/src/private \
     && ln /usr/local/bin/direxec common/entrypoint \
     && ln /usr/local/bin/direxec common/build \

--- a/16.0.Dockerfile
+++ b/16.0.Dockerfile
@@ -92,7 +92,8 @@ COPY build.d common/build.d
 COPY conf.d common/conf.d
 COPY entrypoint.d common/entrypoint.d
 RUN rm -f /opt/odoo/common/conf.d/60-geoip-ge17.conf \
-    && mv /opt/odoo/common/conf.d/60-geoip-lt17.conf /opt/odoo/common/conf.d/60-geoip.conf
+    && mv /opt/odoo/common/conf.d/60-geoip-lt17.conf /opt/odoo/common/conf.d/60-geoip.conf \
+    && rm -f /opt/odoo/common/conf.d/70-database-replica-ge18.conf
 RUN mkdir -p auto/addons auto/geoip custom/src/private \
     && ln /usr/local/bin/direxec common/entrypoint \
     && ln /usr/local/bin/direxec common/build \

--- a/17.0.Dockerfile
+++ b/17.0.Dockerfile
@@ -91,7 +91,8 @@ COPY build.d common/build.d
 COPY conf.d common/conf.d
 COPY entrypoint.d common/entrypoint.d
 RUN rm -f /opt/odoo/common/conf.d/60-geoip-lt17.conf \
-    && mv /opt/odoo/common/conf.d/60-geoip-ge17.conf /opt/odoo/common/conf.d/60-geoip.conf
+    && mv /opt/odoo/common/conf.d/60-geoip-ge17.conf /opt/odoo/common/conf.d/60-geoip.conf \
+    && rm -f /opt/odoo/common/conf.d/70-database-replica-ge18.conf
 RUN mkdir -p auto/addons auto/geoip custom/src/private \
     && ln /usr/local/bin/direxec common/entrypoint \
     && ln /usr/local/bin/direxec common/build \

--- a/18.0.Dockerfile
+++ b/18.0.Dockerfile
@@ -13,6 +13,8 @@ ARG LAST_SYSTEM_GID=499
 ARG FIRST_UID=500
 ARG FIRST_GID=500
 ENV DB_FILTER=.* \
+    PGHOST_REPLICA=false \
+    PGPORT_REPLICA=false \
     DEPTH_DEFAULT=1 \
     DEPTH_MERGE=100 \
     EMAIL=https://hub.docker.com/r/tecnativa/odoo \
@@ -91,7 +93,8 @@ COPY build.d common/build.d
 COPY conf.d common/conf.d
 COPY entrypoint.d common/entrypoint.d
 RUN rm -f /opt/odoo/common/conf.d/60-geoip-lt17.conf \
-    && mv /opt/odoo/common/conf.d/60-geoip-ge17.conf /opt/odoo/common/conf.d/60-geoip.conf
+    && mv /opt/odoo/common/conf.d/60-geoip-ge17.conf /opt/odoo/common/conf.d/60-geoip.conf \
+    && mv /opt/odoo/common/conf.d/70-database-replica-ge18.conf /opt/odoo/common/conf.d/70-database-replica.conf
 RUN mkdir -p auto/addons auto/geoip custom/src/private \
     && ln /usr/local/bin/direxec common/entrypoint \
     && ln /usr/local/bin/direxec common/build \

--- a/19.0.Dockerfile
+++ b/19.0.Dockerfile
@@ -13,6 +13,8 @@ ARG LAST_SYSTEM_GID=499
 ARG FIRST_UID=500
 ARG FIRST_GID=500
 ENV DB_FILTER=.* \
+    PGHOST_REPLICA=None \
+    PGPORT_REPLICA=None \
     DEPTH_DEFAULT=1 \
     DEPTH_MERGE=100 \
     EMAIL=https://hub.docker.com/r/tecnativa/odoo \
@@ -91,7 +93,8 @@ COPY build.d common/build.d
 COPY conf.d common/conf.d
 COPY entrypoint.d common/entrypoint.d
 RUN rm -f /opt/odoo/common/conf.d/60-geoip-lt17.conf \
-    && mv /opt/odoo/common/conf.d/60-geoip-ge17.conf /opt/odoo/common/conf.d/60-geoip.conf
+    && mv /opt/odoo/common/conf.d/60-geoip-ge17.conf /opt/odoo/common/conf.d/60-geoip.conf \
+    && mv /opt/odoo/common/conf.d/70-database-replica-ge18.conf /opt/odoo/common/conf.d/70-database-replica.conf
 RUN mkdir -p auto/addons auto/geoip custom/src/private \
     && ln /usr/local/bin/direxec common/entrypoint \
     && ln /usr/local/bin/direxec common/build \

--- a/conf.d/70-database-replica-ge18.conf
+++ b/conf.d/70-database-replica-ge18.conf
@@ -1,0 +1,4 @@
+[options]
+; Optional read-only database replica settings
+db_replica_host = $PGHOST_REPLICA
+db_replica_port = $PGPORT_REPLICA

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -363,8 +363,35 @@ class ScaffoldingCase(unittest.TestCase):
         )
         smallest_dir = join(SCAFFOLDINGS_DIR, "smallest")
         for sub_env in matrix():
+            if float(sub_env["ODOO_MINOR"]) >= 19.0:
+                # Replicas disabled with None
+                replica_command = (
+                    "grep",
+                    "-x",
+                    "db_replica_host = None",
+                    "/opt/odoo/auto/odoo.conf",
+                )
+            elif float(sub_env["ODOO_MINOR"]) >= 18.0:
+                # Replicas disabled with false
+                replica_command = (
+                    "grep",
+                    "-x",
+                    "db_replica_host = false",
+                    "/opt/odoo/auto/odoo.conf",
+                )
+            else:
+                # Replicas unsupported, settings must not be shipped
+                replica_command = (
+                    "bash",
+                    "-xc",
+                    "! grep -q db_replica /opt/odoo/auto/odoo.conf",
+                )
             self.compose_test(
-                smallest_dir, sub_env, *commands, ("python", "-c", "import watchdog")
+                smallest_dir,
+                sub_env,
+                *commands,
+                replica_command,
+                ("python", "-c", "import watchdog"),
             )
 
     def test_addons_env(self):


### PR DESCRIPTION
Expose `db_replica_host` and `db_replica_port` as `PGHOST_REPLICA` and `PGPORT_REPLICA`. Only Odoo 18.0+ supports them, so 11.0-17.0 drop the new conf file at build time.

The default differs per version because Odoo does not read an empty setting as an absent one: 18.0 needs false, 19.0 needs None. Both match what Odoo writes in odoo/addons/base/tests/config/save_posix.conf.

https://www.odoo.com/documentation/18.0/developer/reference/cli.html#cmdoption-odoo-bin-db_replica_host