### PR TITLE
[IMP] Mount APT and PIP caches during build

### DIFF
--- a/13.0.Dockerfile
+++ b/13.0.Dockerfile
@@ -1,7 +1,8 @@
 FROM python:3.6-slim-buster AS base
 
 EXPOSE 8069 8072
-
+ARG OS_VERSION="buster"
+ARG TARGETARCH
 ARG GEOIP_UPDATER_VERSION=4.1.5
 ARG MQT=https://github.com/OCA/maintainer-quality-tools.git
 ARG WKHTMLTOPDF_VERSION=0.12.5
@@ -19,7 +20,6 @@ ENV DB_FILTER=.* \
     NODE_PATH=/usr/local/lib/node_modules:/usr/lib/node_modules \
     OPENERP_SERVER=/opt/odoo/auto/odoo.conf \
     PATH="/home/odoo/.local/bin:$PATH" \
-    PIP_NO_CACHE_DIR=0 \
     PTVSD_ARGS="--host 0.0.0.0 --port 6899 --wait --multiprocess" \
     PTVSD_ENABLE=0 \
     DEBUGPY_ARGS="--listen 0.0.0.0:6899 --wait-for-client" \
@@ -38,13 +38,17 @@ ENV DB_FILTER=.* \
 RUN sed -i 's,http://deb.debian.org,http://archive.debian.org,g;s,http://security.debian.org,http://archive.debian.org,g' /etc/apt/sources.list
 # Other requirements and recommendations
 # See https://github.com/$ODOO_SOURCE/blob/$ODOO_VERSION/debian/control
-RUN apt-get -qq update \
+RUN --mount=target=/var/lib/apt/lists,type=cache,id=apt-lists-${TARGETARCH}-${OS_VERSION} \
+    --mount=target=/var/cache/apt,type=cache,id=apt-${TARGETARCH}-${OS_VERSION} \
+    --mount=target=/tmp,type=tmpfs \
+    rm -f /etc/apt/apt.conf.d/docker-clean \
+    && apt-get -qq update \
     && apt-get install -yqq --no-install-recommends \
         curl \
-    && curl -SLo wkhtmltox.deb https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/${WKHTMLTOPDF_VERSION}/wkhtmltox_${WKHTMLTOPDF_VERSION}-1.buster_amd64.deb \
-    && echo "${WKHTMLTOPDF_CHECKSUM} wkhtmltox.deb" | sha256sum -c - \
+    && curl -SLo /tmp/wkhtmltox.deb https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/${WKHTMLTOPDF_VERSION}/wkhtmltox_${WKHTMLTOPDF_VERSION}-1.buster_amd64.deb \
+    && echo "${WKHTMLTOPDF_CHECKSUM} /tmp/wkhtmltox.deb" | sha256sum -c - \
     && apt-get install -yqq --no-install-recommends \
-        ./wkhtmltox.deb \
+        /tmp/wkhtmltox.deb \
         chromium \
         ffmpeg \
         fonts-liberation2 \
@@ -62,11 +66,9 @@ RUN apt-get -qq update \
     && curl -SL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
     && apt-get update \
     && apt-get install -yqq --no-install-recommends \
-    && curl --silent -L --output geoipupdate_${GEOIP_UPDATER_VERSION}_linux_amd64.deb https://github.com/maxmind/geoipupdate/releases/download/v${GEOIP_UPDATER_VERSION}/geoipupdate_${GEOIP_UPDATER_VERSION}_linux_amd64.deb \
-    && dpkg -i geoipupdate_${GEOIP_UPDATER_VERSION}_linux_amd64.deb \
-    && rm geoipupdate_${GEOIP_UPDATER_VERSION}_linux_amd64.deb \
+    && curl --silent -L --output /tmp/geoipupdate_${GEOIP_UPDATER_VERSION}_linux_amd64.deb https://github.com/maxmind/geoipupdate/releases/download/v${GEOIP_UPDATER_VERSION}/geoipupdate_${GEOIP_UPDATER_VERSION}_linux_amd64.deb \
+    && dpkg -i /tmp/geoipupdate_${GEOIP_UPDATER_VERSION}_linux_amd64.deb \
     && apt-get autopurge -yqq \
-    && rm -Rf wkhtmltox.deb /var/lib/apt/lists/* /tmp/* \
     && sync
 
 WORKDIR /opt/odoo
@@ -91,7 +93,8 @@ RUN mkdir -p auto/addons auto/geoip custom/src/private \
 
 # Doodba-QA dependencies in a separate virtualenv
 COPY qa /qa
-RUN python -m venv --system-site-packages /qa/venv \
+RUN --mount=target=/root/.cache/pip,type=cache,id=pip-cache \
+    python -m venv --system-site-packages /qa/venv \
     && . /qa/venv/bin/activate \
     && pip install \
         click \
@@ -106,7 +109,11 @@ ARG ODOO_VERSION=13.0
 ENV ODOO_VERSION="$ODOO_VERSION"
 
 # Install Odoo hard & soft dependencies, and Doodba utilities
-RUN build_deps=" \
+RUN --mount=target=/var/lib/apt/lists,type=cache,id=apt-lists-${TARGETARCH}-${OS_VERSION} \
+    --mount=target=/var/cache/apt,type=cache,id=apt-${TARGETARCH}-${OS_VERSION} \
+    --mount=target=/root/.cache/pip,type=cache,id=pip-cache \
+    --mount=target=/tmp,type=tmpfs \
+    build_deps=" \
         build-essential \
         libfreetype6-dev \
         libfribidi-dev \
@@ -149,8 +156,7 @@ RUN build_deps=" \
         inotify \
     && (python3 -m compileall -q /usr/local/lib/python3.6/ || true) \
     && apt-get purge -yqq $build_deps \
-    && apt-get autopurge -yqq \
-    && rm -Rf /var/lib/apt/lists/* /tmp/*
+    && apt-get autopurge -yqq
 
 # Metadata
 ARG VCS_REF
@@ -237,6 +243,10 @@ ONBUILD RUN mkdir -p /opt/odoo/custom/ssh \
             && chmod -R u=rwX,go= /opt/odoo/custom/ssh \
             && sync
 ONBUILD ARG DB_VERSION=latest
-ONBUILD RUN /opt/odoo/common/build && sync
+ONBUILD RUN --mount=target=/var/lib/apt/lists,type=cache,id=apt-lists-${TARGETARCH}-${OS_VERSION} \
+            --mount=target=/var/cache/apt,type=cache,id=apt-${TARGETARCH}-${OS_VERSION} \
+            --mount=target=/root/.cache/pip,type=cache,id=pip-cache \
+            --mount=target=/tmp,type=tmpfs \
+            /opt/odoo/common/build && sync
 ONBUILD VOLUME ["/var/lib/odoo"]
 ONBUILD USER odoo

--- a/14.0.Dockerfile
+++ b/14.0.Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.8-slim-buster AS base
 
 EXPOSE 8069 8072
-
+ARG OS_VERSION="buster"
 ARG TARGETARCH
 ARG GEOIP_UPDATER_VERSION=6.0.0
 ARG WKHTMLTOPDF_VERSION=0.12.5
@@ -20,7 +20,6 @@ ENV DB_FILTER=.* \
     NODE_PATH=/usr/local/lib/node_modules:/usr/lib/node_modules \
     OPENERP_SERVER=/opt/odoo/auto/odoo.conf \
     PATH="/home/odoo/.local/bin:$PATH" \
-    PIP_NO_CACHE_DIR=0 \
     DEBUGPY_ARGS="--listen 0.0.0.0:6899 --wait-for-client" \
     DEBUGPY_ENABLE=0 \
     PUDB_RDB_HOST=0.0.0.0 \
@@ -37,7 +36,11 @@ ENV DB_FILTER=.* \
 RUN sed -i 's,http://deb.debian.org,http://archive.debian.org,g;s,http://security.debian.org,http://archive.debian.org,g' /etc/apt/sources.list
 # Other requirements and recommendations
 # See https://github.com/$ODOO_SOURCE/blob/$ODOO_VERSION/debian/control
-RUN apt-get -qq update \
+RUN --mount=target=/var/lib/apt/lists,type=cache,id=apt-lists-${TARGETARCH}-${OS_VERSION} \
+    --mount=target=/var/cache/apt,type=cache,id=apt-${TARGETARCH}-${OS_VERSION} \
+    --mount=target=/tmp,type=tmpfs \
+    rm -f /etc/apt/apt.conf.d/docker-clean \
+    && apt-get -qq update \
     && apt-get install -yqq --no-install-recommends \
         curl; \
     if [ "$TARGETARCH" = "arm64" ]; then \
@@ -54,13 +57,13 @@ RUN apt-get -qq update \
         echo "Unsupported architecture: $TARGETARCH" >&2; \
         exit 1; \
     fi \
-    && curl -SLo wkhtmltox.deb ${WKHTMLTOPDF_URL} \
+    && curl -SLo /tmp/wkhtmltox.deb ${WKHTMLTOPDF_URL} \
     && echo "Downloading wkhtmltopdf from: ${WKHTMLTOPDF_URL}" \
     && echo "Expected wkhtmltox checksum: ${WKHTMLTOPDF_CHECKSUM}" \
-    && echo "Computed wkhtmltox checksum: $(sha256sum wkhtmltox.deb | awk '{ print $1 }')" \
-    && echo "${WKHTMLTOPDF_CHECKSUM} wkhtmltox.deb" | sha256sum -c - \
+    && echo "Computed wkhtmltox checksum: $(sha256sum /tmp/wkhtmltox.deb | awk '{ print $1 }')" \
+    && echo "${WKHTMLTOPDF_CHECKSUM} /tmp/wkhtmltox.deb" | sha256sum -c - \
     && apt-get install -yqq --no-install-recommends \
-        ./wkhtmltox.deb \
+        /tmp/wkhtmltox.deb \
         chromium \
         ffmpeg \
         fonts-liberation2 \
@@ -77,11 +80,9 @@ RUN apt-get -qq update \
     && echo 'deb https://apt-archive.postgresql.org/pub/repos/apt buster-pgdg main' >> /etc/apt/sources.list.d/postgresql.list \
     && curl -SL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
     && apt-get update \
-    && curl --silent -L --output geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb https://github.com/maxmind/geoipupdate/releases/download/v${GEOIP_UPDATER_VERSION}/geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb \
-    && dpkg -i geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb \
-    && rm geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb \
+    && curl --silent -L --output /tmp/geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb https://github.com/maxmind/geoipupdate/releases/download/v${GEOIP_UPDATER_VERSION}/geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb \
+    && dpkg -i /tmp/geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb \
     && apt-get autopurge -yqq \
-    && rm -Rf wkhtmltox.deb /var/lib/apt/lists/* /tmp/* \
     && sync
 
 WORKDIR /opt/odoo
@@ -106,7 +107,8 @@ RUN mkdir -p auto/addons auto/geoip custom/src/private \
 
 # Doodba-QA dependencies in a separate virtualenv
 COPY qa /qa
-RUN python -m venv --system-site-packages /qa/venv \
+RUN --mount=target=/root/.cache/pip,type=cache,id=pip-cache \
+    python -m venv --system-site-packages /qa/venv \
     && . /qa/venv/bin/activate \
     && pip install \
         click \
@@ -120,7 +122,11 @@ ARG ODOO_VERSION=14.0
 ENV ODOO_VERSION="$ODOO_VERSION"
 
 # Install Odoo hard & soft dependencies, and Doodba utilities
-RUN build_deps=" \
+RUN --mount=target=/var/lib/apt/lists,type=cache,id=apt-lists-${TARGETARCH}-${OS_VERSION} \
+    --mount=target=/var/cache/apt,type=cache,id=apt-${TARGETARCH}-${OS_VERSION} \
+    --mount=target=/root/.cache/pip,type=cache,id=pip-cache \
+    --mount=target=/tmp,type=tmpfs \
+    build_deps=" \
         build-essential \
         libfreetype6-dev \
         libfribidi-dev \
@@ -166,8 +172,7 @@ RUN build_deps=" \
         wdb \
     && (python3 -m compileall -q /usr/local/lib/python3.8/ || true) \
     && apt-get purge -yqq $build_deps \
-    && apt-get autopurge -yqq \
-    && rm -Rf /var/lib/apt/lists/* /tmp/*
+    && apt-get autopurge -yqq
 
 # Metadata
 ARG VCS_REF
@@ -254,6 +259,11 @@ ONBUILD RUN mkdir -p /opt/odoo/custom/ssh \
             && chmod -R u=rwX,go= /opt/odoo/custom/ssh \
             && sync
 ONBUILD ARG DB_VERSION=latest
-ONBUILD RUN /opt/odoo/common/build && sync
+ONBUILD RUN --mount=target=/var/lib/apt/lists,type=cache,id=apt-lists-${TARGETARCH}-${OS_VERSION} \
+            --mount=target=/var/cache/apt,type=cache,id=apt-${TARGETARCH}-${OS_VERSION} \
+            --mount=target=/root/.cache/pip,type=cache,id=pip-cache \
+            --mount=target=/root/.cache/pip,type=cache,id=pip-cache \
+            --mount=target=/tmp,type=tmpfs \
+            /opt/odoo/common/build && sync
 ONBUILD VOLUME ["/var/lib/odoo"]
 ONBUILD USER odoo

--- a/15.0.Dockerfile
+++ b/15.0.Dockerfile
@@ -1,7 +1,6 @@
 FROM python:3.8-slim-bullseye AS base
-
 EXPOSE 8069 8072
-
+ARG OS_VERSION="bullseye"
 ARG TARGETARCH
 ARG GEOIP_UPDATER_VERSION=6.0.0
 ARG WKHTMLTOPDF_VERSION=0.12.5
@@ -20,7 +19,6 @@ ENV DB_FILTER=.* \
     NODE_PATH=/usr/local/lib/node_modules:/usr/lib/node_modules \
     OPENERP_SERVER=/opt/odoo/auto/odoo.conf \
     PATH="/home/odoo/.local/bin:$PATH" \
-    PIP_NO_CACHE_DIR=0 \
     DEBUGPY_ARGS="--listen 0.0.0.0:6899 --wait-for-client" \
     DEBUGPY_ENABLE=0 \
     PUDB_RDB_HOST=0.0.0.0 \
@@ -35,7 +33,11 @@ ENV DB_FILTER=.* \
 
 # Other requirements and recommendations
 # See https://github.com/$ODOO_SOURCE/blob/$ODOO_VERSION/debian/control
-RUN apt-get -qq update \
+RUN --mount=target=/var/lib/apt/lists,type=cache,id=apt-lists-${TARGETARCH}-${OS_VERSION} \
+    --mount=target=/var/cache/apt,type=cache,id=apt-${TARGETARCH}-${OS_VERSION} \
+    --mount=target=/tmp,type=tmpfs \
+    rm -f /etc/apt/apt.conf.d/docker-clean \
+    && apt-get -qq update \
     && apt-get install -yqq --no-install-recommends \
         curl; \
     if [ "$TARGETARCH" = "arm64" ]; then \
@@ -52,12 +54,12 @@ RUN apt-get -qq update \
         echo "Unsupported architecture: $TARGETARCH" >&2; \
         exit 1; \
     fi \
-    && curl -SLo wkhtmltox.deb ${WKHTMLTOPDF_URL} \
+    && curl -SLo /tmp/wkhtmltox.deb ${WKHTMLTOPDF_URL} \
     && echo "Downloading wkhtmltopdf from: ${WKHTMLTOPDF_URL}" \
     && echo "Expected wkhtmltox checksum: ${WKHTMLTOPDF_CHECKSUM}" \
-    && echo "Computed wkhtmltox checksum: $(sha256sum wkhtmltox.deb | awk '{ print $1 }')" \
-    && echo "${WKHTMLTOPDF_CHECKSUM} wkhtmltox.deb" | sha256sum -c - \
-    && (dpkg -i wkhtmltox.deb || apt-get -y install -f) \
+    && echo "Computed wkhtmltox checksum: $(sha256sum /tmp/wkhtmltox.deb | awk '{ print $1 }')" \
+    && echo "${WKHTMLTOPDF_CHECKSUM} /tmp/wkhtmltox.deb" | sha256sum -c - \
+    && (dpkg -i /tmp/wkhtmltox.deb || apt-get -y install -f) \
     && apt-get install -yqq --no-install-recommends \
         chromium \
         ffmpeg \
@@ -74,11 +76,9 @@ RUN apt-get -qq update \
     && echo 'deb https://apt.postgresql.org/pub/repos/apt/ bullseye-pgdg main' >> /etc/apt/sources.list.d/postgresql.list \
     && curl -SL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
     && apt-get update \
-    && curl --silent -L --output geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb https://github.com/maxmind/geoipupdate/releases/download/v${GEOIP_UPDATER_VERSION}/geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb \
-    && dpkg -i geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb \
-    && rm geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb \
+    && curl --silent -L --output /tmp/geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb https://github.com/maxmind/geoipupdate/releases/download/v${GEOIP_UPDATER_VERSION}/geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb \
+    && dpkg -i /tmp/geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb \
     && apt-get autopurge -yqq \
-    && rm -Rf wkhtmltox.deb /var/lib/apt/lists/* /tmp/* \
     && sync
 
 WORKDIR /opt/odoo
@@ -103,7 +103,8 @@ RUN mkdir -p auto/addons auto/geoip custom/src/private \
 
 # Doodba-QA dependencies in a separate virtualenv
 COPY qa /qa
-RUN python -m venv --system-site-packages /qa/venv \
+RUN --mount=target=/root/.cache/pip,type=cache,id=pip-cache \
+    python -m venv --system-site-packages /qa/venv \
     && . /qa/venv/bin/activate \
     && pip install \
         click \
@@ -116,7 +117,11 @@ ARG ODOO_VERSION=15.0
 ENV ODOO_VERSION="$ODOO_VERSION"
 
 # Install Odoo hard & soft dependencies, and Doodba utilities
-RUN build_deps=" \
+RUN --mount=target=/var/lib/apt/lists,type=cache,id=apt-lists-${TARGETARCH}-${OS_VERSION} \
+    --mount=target=/var/cache/apt,type=cache,id=apt-${TARGETARCH}-${OS_VERSION} \
+    --mount=target=/root/.cache/pip,type=cache,id=pip-cache \
+    --mount=target=/tmp,type=tmpfs \
+    build_deps=" \
         build-essential \
         libfreetype6-dev \
         libfribidi-dev \
@@ -163,8 +168,7 @@ RUN build_deps=" \
         wdb \
     && (python3 -m compileall -q /usr/local/lib/python3.8/ || true) \
     && apt-get purge -yqq $build_deps \
-    && apt-get autopurge -yqq \
-    && rm -Rf /var/lib/apt/lists/* /tmp/*
+    && apt-get autopurge -yqq
 
 # Metadata
 ARG VCS_REF
@@ -251,6 +255,10 @@ ONBUILD RUN mkdir -p /opt/odoo/custom/ssh \
             && chmod -R u=rwX,go= /opt/odoo/custom/ssh \
             && sync
 ONBUILD ARG DB_VERSION=latest
-ONBUILD RUN /opt/odoo/common/build && sync
+ONBUILD RUN --mount=target=/var/lib/apt/lists,type=cache,id=apt-lists-${TARGETARCH}-${OS_VERSION} \
+            --mount=target=/var/cache/apt,type=cache,id=apt-${TARGETARCH}-${OS_VERSION} \
+            --mount=target=/root/.cache/pip,type=cache,id=pip-cache \
+            --mount=target=/tmp,type=tmpfs \
+            /opt/odoo/common/build && sync
 ONBUILD VOLUME ["/var/lib/odoo"]
 ONBUILD USER odoo

--- a/16.0.Dockerfile
+++ b/16.0.Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.10-slim-bookworm AS base
 
 EXPOSE 8069 8072
-
+ARG OS_VERSION="bookworm"
 ARG TARGETARCH
 ARG GEOIP_UPDATER_VERSION=6.0.0
 ARG WKHTMLTOPDF_VERSION=0.12.6.1
@@ -26,7 +26,6 @@ ENV DB_FILTER=.* \
     NODE_PATH=/usr/local/lib/node_modules:/usr/lib/node_modules \
     OPENERP_SERVER=/opt/odoo/auto/odoo.conf \
     PATH="/home/odoo/.local/bin:$PATH" \
-    PIP_NO_CACHE_DIR=0 \
     DEBUGPY_ARGS="--listen 0.0.0.0:6899 --wait-for-client" \
     DEBUGPY_ENABLE=0 \
     PUDB_RDB_HOST=0.0.0.0 \
@@ -42,7 +41,11 @@ ENV DB_FILTER=.* \
 
 # Other requirements and recommendations
 # See https://github.com/$ODOO_SOURCE/blob/$ODOO_VERSION/debian/control
-RUN echo "LAST_SYSTEM_UID=$LAST_SYSTEM_UID\nLAST_SYSTEM_GID=$LAST_SYSTEM_GID\nFIRST_UID=$FIRST_UID\nFIRST_GID=$FIRST_GID" >> /etc/adduser.conf \
+RUN --mount=target=/var/lib/apt/lists,type=cache,id=apt-lists-${TARGETARCH}-${OS_VERSION} \
+    --mount=target=/var/cache/apt,type=cache,id=apt-${TARGETARCH}-${OS_VERSION} \
+    --mount=target=/tmp,type=tmpfs \
+    rm -f /etc/apt/apt.conf.d/docker-clean \
+    && echo "LAST_SYSTEM_UID=$LAST_SYSTEM_UID\nLAST_SYSTEM_GID=$LAST_SYSTEM_GID\nFIRST_UID=$FIRST_UID\nFIRST_GID=$FIRST_GID" >> /etc/adduser.conf \
     && echo "SYS_UID_MAX $LAST_SYSTEM_UID\nSYS_GID_MAX $LAST_SYSTEM_GID" >> /etc/login.defs \
     && sed -i -E "s/^UID_MIN\s+[0-9]+.*/UID_MIN $FIRST_UID/;s/^GID_MIN\s+[0-9]+.*/GID_MIN $FIRST_GID/" /etc/login.defs \
     && useradd --system -u $LAST_SYSTEM_UID -s /usr/sbin/nologin -d / systemd-network \
@@ -56,13 +59,13 @@ RUN echo "LAST_SYSTEM_UID=$LAST_SYSTEM_UID\nLAST_SYSTEM_GID=$LAST_SYSTEM_GID\nFI
         echo "Unsupported architecture: $TARGETARCH" >&2; \
         exit 1; \
     fi \
-    && curl -SLo wkhtmltox.deb ${WKHTMLTOPDF_URL} \
+    && curl -SLo /tmp/wkhtmltox.deb ${WKHTMLTOPDF_URL} \
     && echo "Downloading wkhtmltopdf from: ${WKHTMLTOPDF_URL}" \
     && echo "Expected wkhtmltox checksum: ${WKHTMLTOPDF_CHECKSUM}" \
-    && echo "Computed wkhtmltox checksum: $(sha256sum wkhtmltox.deb | awk '{ print $1 }')" \
-    && echo "${WKHTMLTOPDF_CHECKSUM} wkhtmltox.deb" | sha256sum -c - \
+    && echo "Computed wkhtmltox checksum: $(sha256sum /tmp/wkhtmltox.deb | awk '{ print $1 }')" \
+    && echo "${WKHTMLTOPDF_CHECKSUM} /tmp/wkhtmltox.deb" | sha256sum -c - \
     && apt-get install -yqq --no-install-recommends \
-        ./wkhtmltox.deb \
+        /tmp/wkhtmltox.deb \
         chromium \
         ffmpeg \
         fonts-liberation2 \
@@ -78,11 +81,9 @@ RUN echo "LAST_SYSTEM_UID=$LAST_SYSTEM_UID\nLAST_SYSTEM_GID=$LAST_SYSTEM_GID\nFI
     && echo 'deb https://apt.postgresql.org/pub/repos/apt/ bookworm-pgdg main' >> /etc/apt/sources.list.d/postgresql.list \
     && curl -SL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
     && apt-get update \
-    && curl --silent -L --output geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb https://github.com/maxmind/geoipupdate/releases/download/v${GEOIP_UPDATER_VERSION}/geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb \
-    && dpkg -i geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb \
-    && rm geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb \
+    && curl --silent -L --output /tmp/geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb https://github.com/maxmind/geoipupdate/releases/download/v${GEOIP_UPDATER_VERSION}/geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb \
+    && dpkg -i /tmp/geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb \
     && apt-get autopurge -yqq \
-    && rm -Rf wkhtmltox.deb /var/lib/apt/lists/* /tmp/* \
     && sync
 
 WORKDIR /opt/odoo
@@ -107,7 +108,8 @@ RUN mkdir -p auto/addons auto/geoip custom/src/private \
 
 # Doodba-QA dependencies in a separate virtualenv
 COPY qa /qa
-RUN python -m venv --system-site-packages /qa/venv \
+RUN --mount=target=/root/.cache/pip,type=cache,id=pip-cache \
+    python -m venv --system-site-packages /qa/venv \
     && . /qa/venv/bin/activate \
     && pip install \
         click \
@@ -120,7 +122,11 @@ ARG ODOO_VERSION=16.0
 ENV ODOO_VERSION="$ODOO_VERSION"
 
 # Install Odoo hard & soft dependencies, and Doodba utilities
-RUN build_deps=" \
+RUN --mount=target=/var/lib/apt/lists,type=cache,id=apt-lists-${TARGETARCH}-${OS_VERSION} \
+    --mount=target=/var/cache/apt,type=cache,id=apt-${TARGETARCH}-${OS_VERSION} \
+    --mount=target=/root/.cache/pip,type=cache,id=pip-cache \
+    --mount=target=/tmp,type=tmpfs \
+    build_deps=" \
         build-essential \
         libfreetype6-dev \
         libfribidi-dev \
@@ -168,8 +174,7 @@ RUN build_deps=" \
         wdb \
     && (python3 -m compileall -q /usr/local/lib/python3.10/ || true) \
     && apt-get purge -yqq $build_deps \
-    && apt-get autopurge -yqq \
-    && rm -Rf /var/lib/apt/lists/* /tmp/*
+    && apt-get autopurge -yqq
 
 # Metadata
 ARG VCS_REF
@@ -257,6 +262,10 @@ ONBUILD RUN [ -d ~root/.ssh ] && rm -r ~root/.ssh; \
             && chmod -R u=rwX,go= /opt/odoo/custom/ssh \
             && sync
 ONBUILD ARG DB_VERSION=latest
-ONBUILD RUN /opt/odoo/common/build && sync
+ONBUILD RUN --mount=target=/var/lib/apt/lists,type=cache,id=apt-lists-${TARGETARCH}-${OS_VERSION} \
+            --mount=target=/var/cache/apt,type=cache,id=apt-${TARGETARCH}-${OS_VERSION} \
+            --mount=target=/root/.cache/pip,type=cache,id=pip-cache \
+            --mount=target=/tmp,type=tmpfs \
+            /opt/odoo/common/build && sync
 ONBUILD VOLUME ["/var/lib/odoo"]
 ONBUILD USER odoo

--- a/17.0.Dockerfile
+++ b/17.0.Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.10-slim-bookworm AS base
 
 EXPOSE 8069 8072
-
+ARG OS_VERSION="bookworm"
 ARG TARGETARCH
 ARG GEOIP_UPDATER_VERSION=6.0.0
 ARG WKHTMLTOPDF_VERSION=0.12.6.1
@@ -25,7 +25,6 @@ ENV DB_FILTER=.* \
     NODE_PATH=/usr/local/lib/node_modules:/usr/lib/node_modules \
     OPENERP_SERVER=/opt/odoo/auto/odoo.conf \
     PATH="/home/odoo/.local/bin:$PATH" \
-    PIP_NO_CACHE_DIR=0 \
     DEBUGPY_ARGS="--listen 0.0.0.0:6899 --wait-for-client" \
     DEBUGPY_ENABLE=0 \
     PUDB_RDB_HOST=0.0.0.0 \
@@ -40,7 +39,11 @@ ENV DB_FILTER=.* \
 
 # Other requirements and recommendations
 # See https://github.com/$ODOO_SOURCE/blob/$ODOO_VERSION/debian/control
-RUN echo "LAST_SYSTEM_UID=$LAST_SYSTEM_UID\nLAST_SYSTEM_GID=$LAST_SYSTEM_GID\nFIRST_UID=$FIRST_UID\nFIRST_GID=$FIRST_GID" >> /etc/adduser.conf \
+RUN --mount=target=/var/lib/apt/lists,type=cache,id=apt-lists-${TARGETARCH}-${OS_VERSION} \
+    --mount=target=/var/cache/apt,type=cache,id=apt-${TARGETARCH}-${OS_VERSION} \
+    --mount=target=/tmp,type=tmpfs \
+    rm -f /etc/apt/apt.conf.d/docker-clean \
+    && echo "LAST_SYSTEM_UID=$LAST_SYSTEM_UID\nLAST_SYSTEM_GID=$LAST_SYSTEM_GID\nFIRST_UID=$FIRST_UID\nFIRST_GID=$FIRST_GID" >> /etc/adduser.conf \
     && echo "SYS_UID_MAX   $LAST_SYSTEM_UID\nSYS_GID_MAX   $LAST_SYSTEM_GID" >> /etc/login.defs \
     && sed -i -E "s/^UID_MIN\s+[0-9]+.*/UID_MIN   $FIRST_UID/;s/^GID_MIN\s+[0-9]+.*/GID_MIN   $FIRST_GID/" /etc/login.defs \
     && useradd --system -u $LAST_SYSTEM_UID -s /usr/sbin/nologin -d / systemd-network \
@@ -55,13 +58,13 @@ RUN echo "LAST_SYSTEM_UID=$LAST_SYSTEM_UID\nLAST_SYSTEM_GID=$LAST_SYSTEM_GID\nFI
         echo "Unsupported architecture: $TARGETARCH" >&2; \
         exit 1; \
     fi \
-    && curl -SLo wkhtmltox.deb ${WKHTMLTOPDF_URL} \
+    && curl -SLo /tmp/wkhtmltox.deb ${WKHTMLTOPDF_URL} \
     && echo "Downloading wkhtmltopdf from: ${WKHTMLTOPDF_URL}" \
     && echo "Expected wkhtmltox checksum: ${WKHTMLTOPDF_CHECKSUM}" \
-    && echo "Computed wkhtmltox checksum: $(sha256sum wkhtmltox.deb | awk '{ print $1 }')" \
-    && echo "${WKHTMLTOPDF_CHECKSUM} wkhtmltox.deb" | sha256sum -c - \
+    && echo "Computed wkhtmltox checksum: $(sha256sum /tmp/wkhtmltox.deb | awk '{ print $1 }')" \
+    && echo "${WKHTMLTOPDF_CHECKSUM} /tmp/wkhtmltox.deb" | sha256sum -c - \
     && apt-get install -yqq --no-install-recommends \
-        ./wkhtmltox.deb \
+        /tmp/wkhtmltox.deb \
         chromium \
         ffmpeg \
         fonts-liberation2 \
@@ -77,11 +80,9 @@ RUN echo "LAST_SYSTEM_UID=$LAST_SYSTEM_UID\nLAST_SYSTEM_GID=$LAST_SYSTEM_GID\nFI
     && echo 'deb https://apt.postgresql.org/pub/repos/apt/ bookworm-pgdg main' >> /etc/apt/sources.list.d/postgresql.list \
     && curl -SL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
     && apt-get update \
-    && curl --silent -L --output geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb https://github.com/maxmind/geoipupdate/releases/download/v${GEOIP_UPDATER_VERSION}/geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb \
-    && dpkg -i geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb \
-    && rm geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb \
+    && curl --silent -L --output /tmp/geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb https://github.com/maxmind/geoipupdate/releases/download/v${GEOIP_UPDATER_VERSION}/geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb \
+    && dpkg -i /tmp/geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb \
     && apt-get autopurge -yqq \
-    && rm -Rf wkhtmltox.deb /var/lib/apt/lists/* /tmp/* \
     && sync
 
 WORKDIR /opt/odoo
@@ -106,7 +107,8 @@ RUN mkdir -p auto/addons auto/geoip custom/src/private \
 
 # Doodba-QA dependencies in a separate virtualenv
 COPY qa /qa
-RUN python -m venv --system-site-packages /qa/venv \
+RUN --mount=target=/root/.cache/pip,type=cache,id=pip-cache \
+    python -m venv --system-site-packages /qa/venv \
     && . /qa/venv/bin/activate \
     && pip install \
         click \
@@ -119,7 +121,11 @@ ARG ODOO_VERSION=17.0
 ENV ODOO_VERSION="$ODOO_VERSION"
 
 # Install Odoo hard & soft dependencies, and Doodba utilities
-RUN build_deps=" \
+RUN --mount=target=/var/lib/apt/lists,type=cache,id=apt-lists-${TARGETARCH}-${OS_VERSION} \
+    --mount=target=/var/cache/apt,type=cache,id=apt-${TARGETARCH}-${OS_VERSION} \
+    --mount=target=/root/.cache/pip,type=cache,id=pip-cache \
+    --mount=target=/tmp,type=tmpfs \
+    build_deps=" \
         build-essential \
         libfreetype6-dev \
         libfribidi-dev \
@@ -167,9 +173,7 @@ RUN build_deps=" \
         wdb \
     && (python3 -m compileall -q /usr/local/lib/python3.10/ || true) \
     && apt-get purge -yqq $build_deps \
-    && apt-get autopurge -yqq \
-    && rm -Rf /var/lib/apt/lists/* /tmp/*
-
+    && apt-get autopurge -yqq
 # Metadata
 ARG VCS_REF
 ARG BUILD_DATE
@@ -256,6 +260,10 @@ ONBUILD RUN [ -d ~root/.ssh ] && rm -r ~root/.ssh; \
             && chmod -R u=rwX,go= /opt/odoo/custom/ssh \
             && sync
 ONBUILD ARG DB_VERSION=latest
-ONBUILD RUN /opt/odoo/common/build && sync
+ONBUILD RUN --mount=target=/var/lib/apt/lists,type=cache,id=apt-lists-${TARGETARCH}-${OS_VERSION} \
+            --mount=target=/var/cache/apt,type=cache,id=apt-${TARGETARCH}-${OS_VERSION} \
+            --mount=target=/root/.cache/pip,type=cache,id=pip-cache \
+            --mount=target=/tmp,type=tmpfs \
+            /opt/odoo/common/build && sync
 ONBUILD VOLUME ["/var/lib/odoo"]
 ONBUILD USER odoo

--- a/18.0.Dockerfile
+++ b/18.0.Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.10-slim-bookworm AS base
 
 EXPOSE 8069 8072
-
+ARG OS_VERSION="bookworm"
 ARG TARGETARCH
 ARG GEOIP_UPDATER_VERSION=6.0.0
 ARG WKHTMLTOPDF_VERSION=0.12.6.1
@@ -27,7 +27,6 @@ ENV DB_FILTER=.* \
     NODE_PATH=/usr/local/lib/node_modules:/usr/lib/node_modules \
     OPENERP_SERVER=/opt/odoo/auto/odoo.conf \
     PATH="/home/odoo/.local/bin:$PATH" \
-    PIP_NO_CACHE_DIR=0 \
     DEBUGPY_ARGS="--listen 0.0.0.0:6899 --wait-for-client" \
     DEBUGPY_ENABLE=0 \
     PUDB_RDB_HOST=0.0.0.0 \
@@ -42,7 +41,11 @@ ENV DB_FILTER=.* \
 
 # Other requirements and recommendations
 # See https://github.com/$ODOO_SOURCE/blob/$ODOO_VERSION/debian/control
-RUN echo "LAST_SYSTEM_UID=$LAST_SYSTEM_UID\nLAST_SYSTEM_GID=$LAST_SYSTEM_GID\nFIRST_UID=$FIRST_UID\nFIRST_GID=$FIRST_GID" >> /etc/adduser.conf \
+RUN --mount=target=/var/lib/apt/lists,type=cache,id=apt-lists-${TARGETARCH}-${OS_VERSION} \
+    --mount=target=/var/cache/apt,type=cache,id=apt-${TARGETARCH}-${OS_VERSION} \
+    --mount=target=/tmp,type=tmpfs \
+    rm -f /etc/apt/apt.conf.d/docker-clean \
+    && echo "LAST_SYSTEM_UID=$LAST_SYSTEM_UID\nLAST_SYSTEM_GID=$LAST_SYSTEM_GID\nFIRST_UID=$FIRST_UID\nFIRST_GID=$FIRST_GID" >> /etc/adduser.conf \
     && echo "SYS_UID_MAX   $LAST_SYSTEM_UID\nSYS_GID_MAX   $LAST_SYSTEM_GID" >> /etc/login.defs \
     && sed -i -E "s/^UID_MIN\s+[0-9]+.*/UID_MIN   $FIRST_UID/;s/^GID_MIN\s+[0-9]+.*/GID_MIN   $FIRST_GID/" /etc/login.defs \
     && useradd --system -u $LAST_SYSTEM_UID -s /usr/sbin/nologin -d / systemd-network \
@@ -57,13 +60,13 @@ RUN echo "LAST_SYSTEM_UID=$LAST_SYSTEM_UID\nLAST_SYSTEM_GID=$LAST_SYSTEM_GID\nFI
         echo "Unsupported architecture: $TARGETARCH" >&2; \
         exit 1; \
     fi \
-    && curl -SLo wkhtmltox.deb ${WKHTMLTOPDF_URL} \
+    && curl -SLo /tmp/wkhtmltox.deb ${WKHTMLTOPDF_URL} \
     && echo "Downloading wkhtmltopdf from: ${WKHTMLTOPDF_URL}" \
     && echo "Expected wkhtmltox checksum: ${WKHTMLTOPDF_CHECKSUM}" \
-    && echo "Computed wkhtmltox checksum: $(sha256sum wkhtmltox.deb | awk '{ print $1 }')" \
-    && echo "${WKHTMLTOPDF_CHECKSUM} wkhtmltox.deb" | sha256sum -c - \
+    && echo "Computed wkhtmltox checksum: $(sha256sum /tmp/wkhtmltox.deb | awk '{ print $1 }')" \
+    && echo "${WKHTMLTOPDF_CHECKSUM} /tmp/wkhtmltox.deb" | sha256sum -c - \
     && apt-get install -yqq --no-install-recommends \
-        ./wkhtmltox.deb \
+        /tmp/wkhtmltox.deb \
         chromium \
         ffmpeg \
         fonts-liberation2 \
@@ -79,11 +82,9 @@ RUN echo "LAST_SYSTEM_UID=$LAST_SYSTEM_UID\nLAST_SYSTEM_GID=$LAST_SYSTEM_GID\nFI
     && echo 'deb https://apt.postgresql.org/pub/repos/apt/ bookworm-pgdg main' >> /etc/apt/sources.list.d/postgresql.list \
     && curl -SL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
     && apt-get update \
-    && curl --silent -L --output geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb https://github.com/maxmind/geoipupdate/releases/download/v${GEOIP_UPDATER_VERSION}/geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb \
-    && dpkg -i geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb \
-    && rm geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb \
+    && curl --silent -L --output /tmp/geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb https://github.com/maxmind/geoipupdate/releases/download/v${GEOIP_UPDATER_VERSION}/geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb \
+    && dpkg -i /tmp/geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb \
     && apt-get autopurge -yqq \
-    && rm -Rf wkhtmltox.deb /var/lib/apt/lists/* /tmp/* \
     && sync
 
 WORKDIR /opt/odoo
@@ -108,7 +109,8 @@ RUN mkdir -p auto/addons auto/geoip custom/src/private \
 
 # Doodba-QA dependencies in a separate virtualenv
 COPY qa /qa
-RUN python -m venv --system-site-packages /qa/venv \
+RUN --mount=target=/root/.cache/pip,type=cache,id=pip-cache \
+    python -m venv --system-site-packages /qa/venv \
     && . /qa/venv/bin/activate \
     && pip install \
         click \
@@ -121,7 +123,11 @@ ARG ODOO_VERSION=18.0
 ENV ODOO_VERSION="$ODOO_VERSION"
 
 # Install Odoo hard & soft dependencies, and Doodba utilities
-RUN build_deps=" \
+RUN --mount=target=/var/lib/apt/lists,type=cache,id=apt-lists-${TARGETARCH}-${OS_VERSION} \
+    --mount=target=/var/cache/apt,type=cache,id=apt-${TARGETARCH}-${OS_VERSION} \
+    --mount=target=/root/.cache/pip,type=cache,id=pip-cache \
+    --mount=target=/tmp,type=tmpfs \
+    build_deps=" \
         build-essential \
         libfreetype6-dev \
         libfribidi-dev \
@@ -171,9 +177,7 @@ RUN build_deps=" \
         wdb \
     && (python3 -m compileall -q /usr/local/lib/python3.10/ || true) \
     && apt-get purge -yqq $build_deps \
-    && apt-get autopurge -yqq \
-    && rm -Rf /var/lib/apt/lists/* /tmp/*
-
+    && apt-get autopurge -yqq
 # Metadata
 ARG VCS_REF
 ARG BUILD_DATE
@@ -260,6 +264,10 @@ ONBUILD RUN [ -d ~root/.ssh ] && rm -r ~root/.ssh; \
             && chmod -R u=rwX,go= /opt/odoo/custom/ssh \
             && sync
 ONBUILD ARG DB_VERSION=latest
-ONBUILD RUN /opt/odoo/common/build && sync
+ONBUILD RUN --mount=target=/var/lib/apt/lists,type=cache,id=apt-lists-${TARGETARCH}-${OS_VERSION} \
+            --mount=target=/var/cache/apt,type=cache,id=apt-${TARGETARCH}-${OS_VERSION} \
+            --mount=target=/root/.cache/pip,type=cache,id=pip-cache \
+            --mount=target=/tmp,type=tmpfs \
+            /opt/odoo/common/build && sync
 ONBUILD VOLUME ["/var/lib/odoo"]
 ONBUILD USER odoo

--- a/19.0.Dockerfile
+++ b/19.0.Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.12-slim-bookworm AS base
 
 EXPOSE 8069 8072
-
+ARG OS_VERSION="bookworm"
 ARG TARGETARCH
 ARG GEOIP_UPDATER_VERSION=6.0.0
 ARG WKHTMLTOPDF_VERSION=0.12.6.1
@@ -27,7 +27,6 @@ ENV DB_FILTER=.* \
     NODE_PATH=/usr/local/lib/node_modules:/usr/lib/node_modules \
     ODOO_RC=/opt/odoo/auto/odoo.conf \
     PATH="/home/odoo/.local/bin:$PATH" \
-    PIP_NO_CACHE_DIR=0 \
     DEBUGPY_ARGS="--listen 0.0.0.0:6899 --wait-for-client" \
     DEBUGPY_ENABLE=0 \
     PUDB_RDB_HOST=0.0.0.0 \
@@ -42,7 +41,11 @@ ENV DB_FILTER=.* \
 
 # Other requirements and recommendations
 # See https://github.com/$ODOO_SOURCE/blob/$ODOO_VERSION/debian/control
-RUN echo "LAST_SYSTEM_UID=$LAST_SYSTEM_UID\nLAST_SYSTEM_GID=$LAST_SYSTEM_GID\nFIRST_UID=$FIRST_UID\nFIRST_GID=$FIRST_GID" >> /etc/adduser.conf \
+RUN --mount=target=/var/lib/apt/lists,type=cache,id=apt-lists-${TARGETARCH}-${OS_VERSION} \
+    --mount=target=/var/cache/apt,type=cache,id=apt-${TARGETARCH}-${OS_VERSION} \
+    --mount=target=/tmp,type=tmpfs \
+    rm -f /etc/apt/apt.conf.d/docker-clean \
+    && echo "LAST_SYSTEM_UID=$LAST_SYSTEM_UID\nLAST_SYSTEM_GID=$LAST_SYSTEM_GID\nFIRST_UID=$FIRST_UID\nFIRST_GID=$FIRST_GID" >> /etc/adduser.conf \
     && echo "SYS_UID_MAX   $LAST_SYSTEM_UID\nSYS_GID_MAX   $LAST_SYSTEM_GID" >> /etc/login.defs \
     && sed -i -E "s/^UID_MIN\s+[0-9]+.*/UID_MIN   $FIRST_UID/;s/^GID_MIN\s+[0-9]+.*/GID_MIN   $FIRST_GID/" /etc/login.defs \
     && useradd --system -u $LAST_SYSTEM_UID -s /usr/sbin/nologin -d / systemd-network \
@@ -57,13 +60,13 @@ RUN echo "LAST_SYSTEM_UID=$LAST_SYSTEM_UID\nLAST_SYSTEM_GID=$LAST_SYSTEM_GID\nFI
         echo "Unsupported architecture: $TARGETARCH" >&2; \
         exit 1; \
     fi \
-    && curl -SLo wkhtmltox.deb ${WKHTMLTOPDF_URL} \
+    && curl -SLo /tmp/wkhtmltox.deb ${WKHTMLTOPDF_URL} \
     && echo "Downloading wkhtmltopdf from: ${WKHTMLTOPDF_URL}" \
     && echo "Expected wkhtmltox checksum: ${WKHTMLTOPDF_CHECKSUM}" \
-    && echo "Computed wkhtmltox checksum: $(sha256sum wkhtmltox.deb | awk '{ print $1 }')" \
-    && echo "${WKHTMLTOPDF_CHECKSUM} wkhtmltox.deb" | sha256sum -c - \
+    && echo "Computed wkhtmltox checksum: $(sha256sum /tmp/wkhtmltox.deb | awk '{ print $1 }')" \
+    && echo "${WKHTMLTOPDF_CHECKSUM} /tmp/wkhtmltox.deb" | sha256sum -c - \
     && apt-get install -yqq --no-install-recommends \
-        ./wkhtmltox.deb \
+        /tmp/wkhtmltox.deb \
         chromium \
         ffmpeg \
         fonts-liberation2 \
@@ -79,11 +82,9 @@ RUN echo "LAST_SYSTEM_UID=$LAST_SYSTEM_UID\nLAST_SYSTEM_GID=$LAST_SYSTEM_GID\nFI
     && echo 'deb https://apt.postgresql.org/pub/repos/apt/ bookworm-pgdg main' >> /etc/apt/sources.list.d/postgresql.list \
     && curl -SL https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
     && apt-get update \
-    && curl --silent -L --output geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb https://github.com/maxmind/geoipupdate/releases/download/v${GEOIP_UPDATER_VERSION}/geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb \
-    && dpkg -i geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb \
-    && rm geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb \
+    && curl --silent -L --output /tmp/geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb https://github.com/maxmind/geoipupdate/releases/download/v${GEOIP_UPDATER_VERSION}/geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb \
+    && dpkg -i /tmp/geoipupdate_${GEOIP_UPDATER_VERSION}_linux_${TARGETARCH}.deb \
     && apt-get autopurge -yqq \
-    && rm -Rf wkhtmltox.deb /var/lib/apt/lists/* /tmp/* \
     && sync
 
 WORKDIR /opt/odoo
@@ -108,7 +109,8 @@ RUN mkdir -p auto/addons auto/geoip custom/src/private \
 
 # Doodba-QA dependencies in a separate virtualenv
 COPY qa /qa
-RUN python -m venv --system-site-packages /qa/venv \
+RUN --mount=target=/root/.cache/pip,type=cache,id=pip-cache \
+    python -m venv --system-site-packages /qa/venv \
     && . /qa/venv/bin/activate \
     && pip install \
         click \
@@ -121,7 +123,11 @@ ARG ODOO_VERSION=19.0
 ENV ODOO_VERSION="$ODOO_VERSION"
 
 # Install Odoo hard & soft dependencies, and Doodba utilities
-RUN build_deps=" \
+RUN --mount=target=/var/lib/apt/lists,type=cache,id=apt-lists-${TARGETARCH}-${OS_VERSION} \
+    --mount=target=/var/cache/apt,type=cache,id=apt-${TARGETARCH}-${OS_VERSION} \
+    --mount=target=/root/.cache/pip,type=cache,id=pip-cache \
+    --mount=target=/tmp,type=tmpfs \
+    build_deps=" \
         build-essential \
         libfreetype6-dev \
         libfribidi-dev \
@@ -170,8 +176,7 @@ RUN build_deps=" \
         pycairo \
     && (python3 -m compileall -q /usr/local/lib/python3.12/ || true) \
     && apt-get purge -yqq $build_deps \
-    && apt-get autopurge -yqq \
-    && rm -Rf /var/lib/apt/lists/* /tmp/*
+    && apt-get autopurge -yqq
 
 # Metadata
 ARG VCS_REF
@@ -259,6 +264,10 @@ ONBUILD RUN [ -d ~root/.ssh ] && rm -r ~root/.ssh; \
             && chmod -R u=rwX,go= /opt/odoo/custom/ssh \
             && sync
 ONBUILD ARG DB_VERSION=latest
-ONBUILD RUN /opt/odoo/common/build && sync
+ONBUILD RUN --mount=target=/var/lib/apt/lists,type=cache,id=apt-lists-${TARGETARCH}-${OS_VERSION} \
+            --mount=target=/var/cache/apt,type=cache,id=apt-${TARGETARCH}-${OS_VERSION} \
+            --mount=target=/root/.cache/pip,type=cache,id=pip-cache \
+            --mount=target=/tmp,type=tmpfs \
+            /opt/odoo/common/build && sync
 ONBUILD VOLUME ["/var/lib/odoo"]
 ONBUILD USER odoo

--- a/lib/doodbalib/installer.py
+++ b/lib/doodbalib/installer.py
@@ -60,7 +60,7 @@ class Installer(object):
 
 
 class AptInstaller(Installer):
-    _cleanup_commands = [["apt-get", "-y", "autoremove"], "rm -Rf /var/lib/apt/lists/*"]
+    _cleanup_commands = [["apt-get", "-y", "autoremove"]]
     _install_command = [
         "apt-get",
         "-o",

--- a/tests/scaffoldings/repo_merge/custom/build.d/099-create-fake-odoo
+++ b/tests/scaffoldings/repo_merge/custom/build.d/099-create-fake-odoo
@@ -1,10 +1,10 @@
 #!/bin/bash
-rm -rf /tmp/fake-odoo
-mkdir /tmp/fake-odoo
-cd /tmp/fake-odoo
+rm -rf /opt/fake-odoo
+mkdir /opt/fake-odoo
+cd /opt/fake-odoo
 
 git init
-git config --system --add safe.directory /tmp/fake-odoo/.git
+git config --system --add safe.directory /opt/fake-odoo/.git
 touch odoo-bin
 git add odoo-bin
 git commit -m odoo-bin

--- a/tests/scaffoldings/repo_merge/custom/src/repos.yaml
+++ b/tests/scaffoldings/repo_merge/custom/src/repos.yaml
@@ -3,7 +3,7 @@
   defaults:
     depth: $DEPTH_MERGE
   remotes:
-    local: /tmp/fake-odoo
+    local: /opt/fake-odoo
   merges:
     - local branch1
     - local branch2


### PR DESCRIPTION
2nd atempt at getting mounts working. Lets hope no CI gets broken by this one.
Related: https://github.com/Tecnativa/doodba/pull/698

### What:

This PR mounts APT and PIP caches during build time and a tmpfs at /tmp

### Why:

This should speed up rebuilding doodba on local, as builds will now only need to download (pip, apt) and build (pip) packages if they are a newer version.
This is done on v13+ only because older versions we don't test on CI shouldn't change if they work.
### Workflow changes.
If you place things in /tmp during build and intend on using them later, this won't work anymore.

TT32042