### PR TITLE
[FIX] 15.0: Pin security repo to pre-EOL snapshot

### DIFF
--- a/15.0.Dockerfile
+++ b/15.0.Dockerfile
@@ -32,6 +32,8 @@ ENV DB_FILTER=.* \
     WDB_WEB_PORT=1984 \
     WDB_WEB_SERVER=localhost
 
+# Debian bullseye is now EOL
+COPY apt_sources/bullseye.txt /etc/apt/sources.list
 # Other requirements and recommendations
 # See https://github.com/$ODOO_SOURCE/blob/$ODOO_VERSION/debian/control
 RUN --mount=target=/var/lib/apt/lists,type=cache,id=apt-lists-${TARGETARCH}-${ODOO_VERSION},sharing=locked \

--- a/apt_sources/bullseye.txt
+++ b/apt_sources/bullseye.txt
@@ -1,0 +1,6 @@
+# deb http://snapshot.debian.org/archive/debian/20260824T000000Z bullseye main
+deb http://deb.debian.org/debian bullseye main
+# deb http://snapshot.debian.org/archive/debian-security/20260824T000000Z bullseye-security main
+deb [check-valid-until=no] http://snapshot.debian.org/archive/debian-security/20260824T000000Z bullseye-security main
+# deb http://snapshot.debian.org/archive/debian/20260824T000000Z bullseye-updates main
+deb http://deb.debian.org/debian bullseye-updates main


### PR DESCRIPTION
Pins bullseye security to a pre EOL snapshot while a proper solution is found.

TT64415